### PR TITLE
Disable running workflows on push to main branch

### DIFF
--- a/.github/workflows/fortitude-linting.yml
+++ b/.github/workflows/fortitude-linting.yml
@@ -3,8 +3,8 @@ name: Lint with Fortitude
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+#  push:
+#    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -3,8 +3,8 @@ name: Setup Fortran
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+#  push:
+#    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Until all issues stopping the workflows from passing are fixed, there is no point in having the workflow run when pushed to main. It is caused minutes on the Github runners to be wasted.