### PR TITLE
Fix names for workflow jobs

### DIFF
--- a/.github/workflows/fortitude-linting.yml
+++ b/.github/workflows/fortitude-linting.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   test:
+    name: Fortitude-Lint
     runs-on: [ubuntu-latest]
     strategy:
       fail-fast: false

--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   test:
+    name: ${{ matrix.os }}-${{ matrix.toolchain }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.os }}-${{ matrix.toolchain }}
+    name: ${{ matrix.os }}-${{ matrix.toolchain.compiler }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
All the workflow jobs currently have the name tests. This should fix that.