### PR TITLE
Remove gotos in main.f90 and subInterfaceDetail.f90

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -77,173 +77,174 @@
         CALL writeOutput1
         coarse_flcnt_check=0
         print*, 'adam'
- 1      CONTINUE
-        ita = ita + 1
-        ita2 = ita2 + 1
-        totime = totime + deltat
-        !CALL nsMomentumAB
-        !!$acc wait
-        !print *,1
-        !CALL nsMomentum
-        CALL nsMomentum2order
-      ! if (ita .eq. 258)then
-      ! CALL writeOutput1
-      ! print*,'after ns check'
-      ! pause
-      ! endif
-        !!$acc wait
-       ! print *,2
-        CALL velocityBC
-        !!$acc wait
-        !print *,3
-        CALL solidCellBC
-        !$acc wait
-        !print *,4
-        CALL velocityForcing1
-        !CALL velocityForcing1_gh
-        !!$acc wait
-        !print *,5
-        CALL velocityBC
-      ! !!$acc wait
-        !print *,6
-        CALL poissonSolver
-      ! if (ita .eq. 258)then
-      ! CALL writeOutput1
-      ! print*,'after psolv check'
-      ! pause
-      ! endif
-      ! !!$acc wait
-        print *,7
-        CALL pressureForcing1
-        !CALL pressureForcing1_gh
-        !!$acc wait
-        !CALL calculateUcMO
-        !CALL calculateUc
-        !!$acc update host (u, v, w, ut, vt, wt, p, cell)
-       ! CALL writeOutput
-        CALL writeOutput1
-!       if (ita .gt.60000 )then
-!       ita1 = ita1 + 1
-!       CALL computeSumData
-!       CALL computeSumSqData
-!       CALL writeComputeSumData
-!       CALL writeComputeSumSqData
-!       !print*, ita1
-!       end if
-!       IF(ita1 .gt.0 .and. mod(ita1,10000) .eq. 0) THEN
-!           CALL computeAvgData
-!            CALL computePhaseAvgData
+        DO
+                ita = ita + 1
+                ita2 = ita2 + 1
+                totime = totime + deltat
+                !CALL nsMomentumAB
+                !!$acc wait
+                !print *,1
+                !CALL nsMomentum
+                CALL nsMomentum2order
+        ! if (ita .eq. 258)then
+        ! CALL writeOutput1
+        ! print*,'after ns check'
+        ! pause
+        ! endif
+                !!$acc wait
+        ! print *,2
+                CALL velocityBC
+                !!$acc wait
+                !print *,3
+                CALL solidCellBC
+                !$acc wait
+                !print *,4
+                CALL velocityForcing1
+                !CALL velocityForcing1_gh
+                !!$acc wait
+                !print *,5
+                CALL velocityBC
+        ! !!$acc wait
+                !print *,6
+                CALL poissonSolver
+        ! if (ita .eq. 258)then
+        ! CALL writeOutput1
+        ! print*,'after psolv check'
+        ! pause
+        ! endif
+        ! !!$acc wait
+                print *,7
+                CALL pressureForcing1
+                !CALL pressureForcing1_gh
+                !!$acc wait
+                !CALL calculateUcMO
+                !CALL calculateUc
+                !!$acc update host (u, v, w, ut, vt, wt, p, cell)
+        ! CALL writeOutput
+                CALL writeOutput1
+        !       if (ita .gt.60000 )then
+        !       ita1 = ita1 + 1
+        !       CALL computeSumData
+        !       CALL computeSumSqData
+        !       CALL writeComputeSumData
+        !       CALL writeComputeSumSqData
+        !       !print*, ita1
+        !       end if
+        !       IF(ita1 .gt.0 .and. mod(ita1,10000) .eq. 0) THEN
+        !           CALL computeAvgData
+        !            CALL computePhaseAvgData
 
-!       !print*, ita1
-!       !if (st_flag .eq. 0 )then
-!       !CALL stressCal1_fl
-!       !end if
-!       !CALL stressCal2_fl
-!
-!            CALL writeAvgoutput
-!            CALL writeAvgoutput_fl
-!       END IF
-        !print*,'2'
-        !print *,8
-        !!$acc wait
-!!        CALL stressCal2
-        !print*,'3'
+        !       !print*, ita1
+        !       !if (st_flag .eq. 0 )then
+        !       !CALL stressCal1_fl
+        !       !end if
+        !       !CALL stressCal2_fl
+        !
+        !            CALL writeAvgoutput
+        !            CALL writeAvgoutput_fl
+        !       END IF
+                !print*,'2'
+                !print *,8
+                !!$acc wait
+        !!        CALL stressCal2
+                !print*,'3'
 
-        !print *,9
-        !CALL writeStressData_fl
-!       CALL writeStressData
-!       CALL write_fl_points
-        !$acc wait
-        !print *,10
-        CALL writeResult
-        !$acc wait
-        CALL body_plot
-       ! print*,solverTime, coupTime
-        DO g=blk_start, nblocks
-        DEALLOCATE(block(g)%xcent, block(g)%ycent, block(g)%zcent,block(g)%cosAlpha, block(g)%cosBeta, block(g)%cosGamma,block(g)%alpha3,block(g)%beta3, block(g)%gamma3)
-            block(g)%blk_mv_tag=0.
+                !print *,9
+                !CALL writeStressData_fl
+        !       CALL writeStressData
+        !       CALL write_fl_points
+                !$acc wait
+                !print *,10
+                CALL writeResult
+                !$acc wait
+                CALL body_plot
+        ! print*,solverTime, coupTime
+                DO g=blk_start, nblocks
+                DEALLOCATE(block(g)%xcent, block(g)%ycent, block(g)%zcent,block(g)%cosAlpha, block(g)%cosBeta, block(g)%cosGamma,block(g)%alpha3,block(g)%beta3, block(g)%gamma3)
+                block(g)%blk_mv_tag=0.
+                END DO
+                !DEALLOCATE (cell2)
+                print *,10
+                CALL computeSurfaceVariables
+                CALL block_move_check
+                !print*,ita,block(2)%y1(1),block(2)%yp(1)
+                CALL change_block_coords
+                !print*,ita,block(2)%y1(1),block(2)%yp(1)
+                CALL change_block_interface
+                CALL fine_block_cell
+                CALL cellCount_solid_coarse_mv
+                !print*,ita,block(2)%y1(1),block(2)%yp(1)
+                print*,1
+                CALL computeSurfaceNorm
+                print*,2
+                CALL tagging_th_move
+                ! print*,3
+        !  if (block(2)%blk_mv_tag .eq. 1)then
+        ! CALL writeOutput1
+        ! print*,'!!!!!!!!check!!!!!!!!!!!!'
+        ! pause
+        ! endif
+                CALL selectiveRetagging_th
+                ! print*,4
+                !!print*,'!!!!yp!!!!!!!!!',block(2)%yp(160)
+        !print*,'After selective retagging'
+        !  CALL amgx_matrix
+        !print*,'After amgx_matrix'
+                !CALL tagging
+                DO g=blk_start, nblocks
+                block(g)%blk_mv_tag=0.
+                        DEALLOCATE(block(g)%index_ts,block(g)% TSIndexPtr,block(g)% interceptedIndexPtr,block(g)% pNormDis,block(g)% nelp,block(g)% nelu1,block(g)% nelu2,block(g)% nelv1,block(g)% nelv2,block(g)% nelw1,block(g)% nelw2,block(g)% u1NormDis,block(g)% u2NormDis ,block(g)% v1NormDis,block(g)% v2NormDis,block(g)% w1NormDis,block(g)% w2NormDis,block(g)% solidIndexPtr)
+                DEALLOCATE( block(g)%fluidIndexPtr,block(g)% redCellIndexPtr, block(g)%blackCellIndexPtr)
+                DEALLOCATE(block(g)%p_ghost,block(g)% pt_ghost,block(g)% u2_ghost,block(g)% u2t_ghost,block(g)% v2_ghost,block(g)% v2t_ghost,block(g)% w2_ghost, block(g)%w2t_ghost,block(g)% u1_ghost,block(g)% u1t_ghost,block(g)% v1_ghost,block(g)% v1t_ghost, block(g)%w1_ghost,block(g)% w1t_ghost)
+        !   	DEALLOCATE(block(g)%pNormDis, block(g)%nelp, &
+        !       block(g)%nelu1, block(g)%nelu2, block(g)%nelv1, &
+        !       block(g)%nelv2, block(g)%nelw1, block(g)%nelw2, &
+        !       block(g)%u1NormDis, block(g)%u2NormDis , block(g)%v1NormDis, &
+        !       block(g)%v2NormDis , block(g)%w1NormDis, block(g)%w2NormDis)
+                !  DEALLOCATE(block(g)%interceptedIndexPtr, block(g)%pNormDis,block(g)%nelp, &
+                !    block(g)%nelu1, block(g)%nelu2, block(g)%nelv1, block(g)%nelv2, block(g)%u1NormDis, block(g)%u2NormDis, &
+                !    block(g)%v1NormDis, block(g)%v2NormDis,block(g)%solidIndexPtr)
+        !print*,'After deallocate'
+                !DO i=1,nblocks
+        !                DEALLOCATE(block(g)%interceptedIndexPtr,block(g)%fluidIndexPtr,block(g)%redCellIndexPtr,block(g)%blackCellIndexPtr,block(g)%solidIndexPtr)
+                !END DO
         END DO
-          !DEALLOCATE (cell2)
-        print *,10
-            CALL computeSurfaceVariables
-           CALL block_move_check
-           !print*,ita,block(2)%y1(1),block(2)%yp(1)
-           CALL change_block_coords
-           !print*,ita,block(2)%y1(1),block(2)%yp(1)
-           CALL change_block_interface
-          CALL fine_block_cell
-          CALL cellCount_solid_coarse_mv
-           !print*,ita,block(2)%y1(1),block(2)%yp(1)
-           print*,1
-           CALL computeSurfaceNorm
-           print*,2
-           CALL tagging_th_move
-         ! print*,3
-      !  if (block(2)%blk_mv_tag .eq. 1)then
-      ! CALL writeOutput1
-      ! print*,'!!!!!!!!check!!!!!!!!!!!!'
-      ! pause
-      ! endif
-           CALL selectiveRetagging_th
-          ! print*,4
-          !!print*,'!!!!yp!!!!!!!!!',block(2)%yp(160)
-       !print*,'After selective retagging'
-       !  CALL amgx_matrix
-       !print*,'After amgx_matrix'
-           !CALL tagging
-        DO g=blk_start, nblocks
-            block(g)%blk_mv_tag=0.
-                DEALLOCATE(block(g)%index_ts,block(g)% TSIndexPtr,block(g)% interceptedIndexPtr,block(g)% pNormDis,block(g)% nelp,block(g)% nelu1,block(g)% nelu2,block(g)% nelv1,block(g)% nelv2,block(g)% nelw1,block(g)% nelw2,block(g)% u1NormDis,block(g)% u2NormDis ,block(g)% v1NormDis,block(g)% v2NormDis,block(g)% w1NormDis,block(g)% w2NormDis,block(g)% solidIndexPtr)
-        DEALLOCATE( block(g)%fluidIndexPtr,block(g)% redCellIndexPtr, block(g)%blackCellIndexPtr)
-        DEALLOCATE(block(g)%p_ghost,block(g)% pt_ghost,block(g)% u2_ghost,block(g)% u2t_ghost,block(g)% v2_ghost,block(g)% v2t_ghost,block(g)% w2_ghost, block(g)%w2t_ghost,block(g)% u1_ghost,block(g)% u1t_ghost,block(g)% v1_ghost,block(g)% v1t_ghost, block(g)%w1_ghost,block(g)% w1t_ghost)
-!   	DEALLOCATE(block(g)%pNormDis, block(g)%nelp, &
-!       block(g)%nelu1, block(g)%nelu2, block(g)%nelv1, &
-!       block(g)%nelv2, block(g)%nelw1, block(g)%nelw2, &
-!       block(g)%u1NormDis, block(g)%u2NormDis , block(g)%v1NormDis, &
-!       block(g)%v2NormDis , block(g)%w1NormDis, block(g)%w2NormDis)
-          !  DEALLOCATE(block(g)%interceptedIndexPtr, block(g)%pNormDis,block(g)%nelp, &
-          !    block(g)%nelu1, block(g)%nelu2, block(g)%nelv1, block(g)%nelv2, block(g)%u1NormDis, block(g)%u2NormDis, &
-          !    block(g)%v1NormDis, block(g)%v2NormDis,block(g)%solidIndexPtr)
-       !print*,'After deallocate'
-           !DO i=1,nblocks
-!                DEALLOCATE(block(g)%interceptedIndexPtr,block(g)%fluidIndexPtr,block(g)%redCellIndexPtr,block(g)%blackCellIndexPtr,block(g)%solidIndexPtr)
-           !END DO
-       END DO
-       !print*,'After deallocate'
+        !print*,'After deallocate'
 
-            CALL cellCount_solid
-        DO g=blk_start, nblocks
-            call solidCellBC_move(g)
-             call updateVelocity_newv(g)
-             !call writeOutput
-             !pause
-!            if (block(g)%move_check .eq. 1)then
-!       CALL writeOutput1
-!       print*,'!!!!!!!!check2!!!!!!!!!!!!'
-!               pause
-!               endif
-            block(g)%move_check=0.
-        ENDDO
-           !CALL coarseUpdate
-            !CALL cellCount
-           CALL computeNormDistance
-        CALL findTScells
-! 2 CONTINUE
-      !!  print*,'11'
-        CALL cpu_time(dStart1)
-        CALL velocityForcingField
-     !!   print*,'12'
-        CALL pressureForcingField
-        CALL cpu_time(dFinish1)
-     !!   print*,'13'
-!        PRINT*, 'time Field Forcing = ', dStart1 - dFinish1
-        CALL cpu_time(dStart1)
-        CALL velocityForcingGhost
-     !!   print*,'14'
-        CALL pressureForcingGhost
-     !!   print*,'15'
-        CALL cpu_time(dFinish1)
-        IF(ita<itamax) GOTO 1
+                CALL cellCount_solid
+                DO g=blk_start, nblocks
+                call solidCellBC_move(g)
+                call updateVelocity_newv(g)
+                !call writeOutput
+                !pause
+        !            if (block(g)%move_check .eq. 1)then
+        !       CALL writeOutput1
+        !       print*,'!!!!!!!!check2!!!!!!!!!!!!'
+        !               pause
+        !               endif
+                block(g)%move_check=0.
+                ENDDO
+                !CALL coarseUpdate
+                !CALL cellCount
+                CALL computeNormDistance
+                CALL findTScells
+        ! 2 CONTINUE
+        !!  print*,'11'
+                CALL cpu_time(dStart1)
+                CALL velocityForcingField
+        !!   print*,'12'
+                CALL pressureForcingField
+                CALL cpu_time(dFinish1)
+        !!   print*,'13'
+        !        PRINT*, 'time Field Forcing = ', dStart1 - dFinish1
+                CALL cpu_time(dStart1)
+                CALL velocityForcingGhost
+        !!   print*,'14'
+                CALL pressureForcingGhost
+        !!   print*,'15'
+                CALL cpu_time(dFinish1)
+                IF(ita>=itamax) EXIT
+        END DO
       END PROGRAM main
 
 

--- a/src/InterfaceDetail.f90
+++ b/src/InterfaceDetail.f90
@@ -93,22 +93,21 @@
         starter=1+1
         ender=starter+factor-1
         intfr(g)%counterxp=2
-12      CONTINUE
+        DO
 
-        intfr(g)%px_interface_det(1,intfr(g)%counterxp)=xx1_p
-        intfr(g)%px_interface_det(2,intfr(g)%counterxp)=starter
-        intfr(g)%px_interface_det(3,intfr(g)%counterxp)=ender
-        !write(*,91) 'px',starter,ender,block(a_blk_no)%xp(xx1_p),block(b_blk_no)%xp(starter),block(b_blk_no)%xp(ender)
-!91      !format(A2,2I3,3F6.3)
+                intfr(g)%px_interface_det(1,intfr(g)%counterxp)=xx1_p
+                intfr(g)%px_interface_det(2,intfr(g)%counterxp)=starter
+                intfr(g)%px_interface_det(3,intfr(g)%counterxp)=ender
+                !write(*,91) 'px',starter,ender,block(a_blk_no)%xp(xx1_p),block(b_blk_no)%xp(starter),block(b_blk_no)%xp(ender)
+        !91      !format(A2,2I3,3F6.3)
 
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counterxp=intfr(g)%counterxp+1
-        xx1_p=xx1_p+1
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counterxp=intfr(g)%counterxp+1
+                xx1_p=xx1_p+1
 
-        if(xx1_p <= xx2_p)then
-                GOTO 12
-        endif
+                if(xx1_p > xx2_p) EXIT
+        END DO
 
 
         intfr(g)%px_interface_det(1,intfr(g)%counterxp)=xx2_p+1
@@ -145,19 +144,18 @@
         starter=1+1
         ender=starter+factor-1
         intfr(g)%counteryp=2
-13      CONTINUE
+        DO
 
-        intfr(g)%py_interface_det(1,intfr(g)%counteryp)=yy1_p
-        intfr(g)%py_interface_det(2,intfr(g)%counteryp)=starter
-        intfr(g)%py_interface_det(3,intfr(g)%counteryp)=ender
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counteryp=intfr(g)%counteryp+1
-        yy1_p=yy1_p+1
+                intfr(g)%py_interface_det(1,intfr(g)%counteryp)=yy1_p
+                intfr(g)%py_interface_det(2,intfr(g)%counteryp)=starter
+                intfr(g)%py_interface_det(3,intfr(g)%counteryp)=ender
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counteryp=intfr(g)%counteryp+1
+                yy1_p=yy1_p+1
 
-        if(yy1_p <= yy2_p)then
-                GOTO 13
-        endif
+                if(yy1_p > yy2_p) EXIT
+        END DO
 
 
         intfr(g)%py_interface_det(1,intfr(g)%counteryp)=yy2_p+1
@@ -191,19 +189,18 @@
         starter=1+1
         ender=starter+factor-1
         intfr(g)%counterzp=2
-913      CONTINUE
+        DO
 
-        intfr(g)%pz_interface_det(1,intfr(g)%counterzp)=zz1_p
-        intfr(g)%pz_interface_det(2,intfr(g)%counterzp)=starter
-        intfr(g)%pz_interface_det(3,intfr(g)%counterzp)=ender
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counterzp=intfr(g)%counterzp+1
-        zz1_p=zz1_p+1
+                intfr(g)%pz_interface_det(1,intfr(g)%counterzp)=zz1_p
+                intfr(g)%pz_interface_det(2,intfr(g)%counterzp)=starter
+                intfr(g)%pz_interface_det(3,intfr(g)%counterzp)=ender
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counterzp=intfr(g)%counterzp+1
+                zz1_p=zz1_p+1
 
-        if(zz1_p <= zz2_p)then
-                GOTO 913
-        endif
+                if(zz1_p > zz2_p) EXIT
+        END DO
 
 
         intfr(g)%pz_interface_det(1,intfr(g)%counterzp)=zz2_p+1
@@ -237,19 +234,18 @@
         ender=starter+factor-1
         intfr(g)%counterxu=2
         print*,block(a_blk_no)%xu(xx1_p),block(a_blk_no)%xu(xx2_p),block(b_blk_no)%xu(2)
-121      CONTINUE
+        DO
 
-        xx1_p=xx1_p+1
-        intfr(g)%ux_interface_det(1,intfr(g)%counterxu)=xx1_p
-        intfr(g)%ux_interface_det(2,intfr(g)%counterxu)=starter
-        intfr(g)%ux_interface_det(3,intfr(g)%counterxu)=ender
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counterxu=intfr(g)%counterxu+1
+                xx1_p=xx1_p+1
+                intfr(g)%ux_interface_det(1,intfr(g)%counterxu)=xx1_p
+                intfr(g)%ux_interface_det(2,intfr(g)%counterxu)=starter
+                intfr(g)%ux_interface_det(3,intfr(g)%counterxu)=ender
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counterxu=intfr(g)%counterxu+1
 
-        if(xx1_p < xx2_p)then
-                GOTO 121
-        endif
+                if(xx1_p >= xx2_p) EXIT
+        END DO
 
 
         intfr(g)%ux_interface_det(1,intfr(g)%counterxu)=xx2_p+1
@@ -283,19 +279,18 @@
         starter=1+1
         ender=starter+factor-1
         intfr(g)%counteryu=2
-131      CONTINUE
+        DO
 
-        intfr(g)%uy_interface_det(1,intfr(g)%counteryu)=yy1_p
-        intfr(g)%uy_interface_det(2,intfr(g)%counteryu)=starter
-        intfr(g)%uy_interface_det(3,intfr(g)%counteryu)=ender
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counteryu=intfr(g)%counteryu+1
-        yy1_p=yy1_p+1
+                intfr(g)%uy_interface_det(1,intfr(g)%counteryu)=yy1_p
+                intfr(g)%uy_interface_det(2,intfr(g)%counteryu)=starter
+                intfr(g)%uy_interface_det(3,intfr(g)%counteryu)=ender
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counteryu=intfr(g)%counteryu+1
+                yy1_p=yy1_p+1
 
-        if(yy1_p <= yy2_p)then
-                GOTO 131
-        endif
+                if(yy1_p > yy2_p) EXIT
+        END DO
 
 
         intfr(g)%uy_interface_det(1,intfr(g)%counteryu)=yy2_p+1
@@ -330,19 +325,18 @@
         starter=1+1
         ender=starter+factor-1
         intfr(g)%counterzu=2
-9131      CONTINUE
+        DO
 
-        intfr(g)%uz_interface_det(1,intfr(g)%counterzu)=zz1_p
-        intfr(g)%uz_interface_det(2,intfr(g)%counterzu)=starter
-        intfr(g)%uz_interface_det(3,intfr(g)%counterzu)=ender
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counterzu=intfr(g)%counterzu+1
-        zz1_p=zz1_p+1
+                intfr(g)%uz_interface_det(1,intfr(g)%counterzu)=zz1_p
+                intfr(g)%uz_interface_det(2,intfr(g)%counterzu)=starter
+                intfr(g)%uz_interface_det(3,intfr(g)%counterzu)=ender
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counterzu=intfr(g)%counterzu+1
+                zz1_p=zz1_p+1
 
-        if(zz1_p <= zz2_p)then
-                GOTO 9131
-        endif
+                if(zz1_p > zz2_p) EXIT
+        END DO
 
 
         intfr(g)%uz_interface_det(1,intfr(g)%counterzu)=zz2_p+1
@@ -375,19 +369,18 @@
         starter=1+1
         ender=starter+factor-1
         intfr(g)%counterxv=2
-122      CONTINUE
+        DO
 
-        intfr(g)%vx_interface_det(1,intfr(g)%counterxv)=xx1_p
-        intfr(g)%vx_interface_det(2,intfr(g)%counterxv)=starter
-        intfr(g)%vx_interface_det(3,intfr(g)%counterxv)=ender
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counterxv=intfr(g)%counterxv+1
-        xx1_p=xx1_p+1
+                intfr(g)%vx_interface_det(1,intfr(g)%counterxv)=xx1_p
+                intfr(g)%vx_interface_det(2,intfr(g)%counterxv)=starter
+                intfr(g)%vx_interface_det(3,intfr(g)%counterxv)=ender
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counterxv=intfr(g)%counterxv+1
+                xx1_p=xx1_p+1
 
-        if(xx1_p <= xx2_p)then
-                GOTO 122
-        endif
+                if(xx1_p > xx2_p) EXIT
+        END DO
 
 
         intfr(g)%vx_interface_det(1,intfr(g)%counterxv)=xx2_p+1
@@ -421,19 +414,18 @@
         starter=2+1
         ender=starter+factor-1
         intfr(g)%counteryv=2
-132      CONTINUE
-        yy1_p=yy1_p+1
+        DO
+                yy1_p=yy1_p+1
 
-        intfr(g)%vy_interface_det(1,intfr(g)%counteryv)=yy1_p
-        intfr(g)%vy_interface_det(2,intfr(g)%counteryv)=starter
-        intfr(g)%vy_interface_det(3,intfr(g)%counteryv)=ender
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counteryv=intfr(g)%counteryv+1
+                intfr(g)%vy_interface_det(1,intfr(g)%counteryv)=yy1_p
+                intfr(g)%vy_interface_det(2,intfr(g)%counteryv)=starter
+                intfr(g)%vy_interface_det(3,intfr(g)%counteryv)=ender
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counteryv=intfr(g)%counteryv+1
 
-        if(yy1_p < yy2_p)then
-                GOTO 132
-        endif
+                if(yy1_p >= yy2_p) EXIT
+        END DO
 
 
         intfr(g)%vy_interface_det(1,intfr(g)%counteryv)=yy2_p+1
@@ -466,19 +458,18 @@
         starter=1+1
         ender=starter+factor-1
         intfr(g)%counterzv=2
-9122      CONTINUE
+        DO
 
-        intfr(g)%vz_interface_det(1,intfr(g)%counterzv)=zz1_p
-        intfr(g)%vz_interface_det(2,intfr(g)%counterzv)=starter
-        intfr(g)%vz_interface_det(3,intfr(g)%counterzv)=ender
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counterzv=intfr(g)%counterzv+1
-        zz1_p=zz1_p+1
+                intfr(g)%vz_interface_det(1,intfr(g)%counterzv)=zz1_p
+                intfr(g)%vz_interface_det(2,intfr(g)%counterzv)=starter
+                intfr(g)%vz_interface_det(3,intfr(g)%counterzv)=ender
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counterzv=intfr(g)%counterzv+1
+                zz1_p=zz1_p+1
 
-        if(zz1_p <= zz2_p)then
-                GOTO 9122
-        endif
+                if(zz1_p > zz2_p) EXIT
+        END DO
 
 
         intfr(g)%vz_interface_det(1,intfr(g)%counterzv)=zz2_p+1
@@ -512,19 +503,18 @@
         starter=1+1
         ender=starter+factor-1
         intfr(g)%counterxw=2
-1229      CONTINUE
+        DO
 
-        intfr(g)%wx_interface_det(1,intfr(g)%counterxw)=xx1_p
-        intfr(g)%wx_interface_det(2,intfr(g)%counterxw)=starter
-        intfr(g)%wx_interface_det(3,intfr(g)%counterxw)=ender
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counterxw=intfr(g)%counterxw+1
-        xx1_p=xx1_p+1
+                intfr(g)%wx_interface_det(1,intfr(g)%counterxw)=xx1_p
+                intfr(g)%wx_interface_det(2,intfr(g)%counterxw)=starter
+                intfr(g)%wx_interface_det(3,intfr(g)%counterxw)=ender
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counterxw=intfr(g)%counterxw+1
+                xx1_p=xx1_p+1
 
-        if(xx1_p <= xx2_p)then
-                GOTO 1229
-        endif
+                if(xx1_p > xx2_p) EXIT
+        END DO
 
 
         intfr(g)%wx_interface_det(1,intfr(g)%counterxw)=xx2_p+1
@@ -558,19 +548,18 @@
         starter=1+1
         ender=starter+factor-1
         intfr(g)%counteryw=2
-1329      CONTINUE
+        DO
 
-        intfr(g)%wy_interface_det(1,intfr(g)%counteryw)=yy1_p
-        intfr(g)%wy_interface_det(2,intfr(g)%counteryw)=starter
-        intfr(g)%wy_interface_det(3,intfr(g)%counteryw)=ender
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counteryw=intfr(g)%counteryw+1
-        yy1_p=yy1_p+1
+                intfr(g)%wy_interface_det(1,intfr(g)%counteryw)=yy1_p
+                intfr(g)%wy_interface_det(2,intfr(g)%counteryw)=starter
+                intfr(g)%wy_interface_det(3,intfr(g)%counteryw)=ender
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counteryw=intfr(g)%counteryw+1
+                yy1_p=yy1_p+1
 
-        if(yy1_p <= yy2_p)then
-                GOTO 1329
-        endif
+                if(yy1_p > yy2_p) EXIT
+        END DO
 
 
         intfr(g)%wy_interface_det(1,intfr(g)%counteryw)=yy2_p+1
@@ -603,21 +592,20 @@
         starter=2+1
         ender=starter+factor-1
         intfr(g)%counterzw=2
-91229      CONTINUE
+        DO
 
-        zz1_p=zz1_p+1
-        intfr(g)%wz_interface_det(1,intfr(g)%counterzw)=zz1_p
-        intfr(g)%wz_interface_det(2,intfr(g)%counterzw)=starter
-        intfr(g)%wz_interface_det(3,intfr(g)%counterzw)=ender
-!        write(*,91) 'wz',starter,ender,block(a_blk_no)%zw(xx1_p),block(b_blk_no)%zwp(starter),block(b_blk_no)%zw(ender)
-!91     format(A2,2I3,3F6.3)
-        starter=ender+1
-        ender=ender+factor
-        intfr(g)%counterzw=intfr(g)%counterzw+1
+                zz1_p=zz1_p+1
+                intfr(g)%wz_interface_det(1,intfr(g)%counterzw)=zz1_p
+                intfr(g)%wz_interface_det(2,intfr(g)%counterzw)=starter
+                intfr(g)%wz_interface_det(3,intfr(g)%counterzw)=ender
+        !        write(*,91) 'wz',starter,ender,block(a_blk_no)%zw(xx1_p),block(b_blk_no)%zwp(starter),block(b_blk_no)%zw(ender)
+        !91     format(A2,2I3,3F6.3)
+                starter=ender+1
+                ender=ender+factor
+                intfr(g)%counterzw=intfr(g)%counterzw+1
 
-        if(zz1_p < zz2_p)then
-                GOTO 91229
-        endif
+                if(zz1_p >= zz2_p) EXIT
+        END DO
 
 
         intfr(g)%wz_interface_det(1,intfr(g)%counterzw)=zz2_p+1


### PR DESCRIPTION
This PR removes the gotos in main.f90 and subInterfaceDetail.f90 . 

Gotos remain in other subSearch.f90 and subPcorVcor.f90, but these shall be left for now until it is decided what is happening with the commented out code, since how to remove the gotos in these files will depend on what happens with the commented out out code.