### PR TITLE
Add dev to workflow branch activation

### DIFF
--- a/.github/workflows/fortitude-linting.yml
+++ b/.github/workflows/fortitude-linting.yml
@@ -3,7 +3,7 @@ name: Lint with Fortitude
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main,dev]
 #  push:
 #    branches: [main]
 

--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -3,7 +3,7 @@ name: Setup Fortran
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main,dev]
 #  push:
 #    branches: [main]
 


### PR DESCRIPTION
Now that we are pushing changes to a dev branch, before going to main, we need to add dev to our list of branches for our workflows. This ensures that the workflows activate for PRs.