### PR TITLE
Apply Werror=unused in ci for gfortran

### DIFF
--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -42,4 +42,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           # Build with FPM
-          fpm build --flag ${{ matrix.toolchain.FFLAGS }}
+          fpm build

--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         toolchain:
-          - {compiler: gcc, version: 14}
+          - {compiler: gcc, version: 14, FFLAGS: "-Werror=unused"}
           - {compiler: intel, version: '2025.0'}
           - {compiler: intel-classic, version: '2021.10'}
           - {compiler: nvidia-hpc, version: '25.1'}
@@ -42,4 +42,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           # Build with FPM
+	  export FPM_FFLAGS="${{ matrix.toolchain.FFLAGS }}"
           fpm build

--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -15,6 +15,8 @@ jobs:
   test:
     name: ${{ matrix.os }}-${{ matrix.toolchain.compiler }}
     runs-on: ${{ matrix.os }}
+    env:
+      FPM_FFLAGS: ${{ matrix.toolchain.FPM_FFLAGS }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         toolchain:
-          - {compiler: gcc, version: 14, FFLAGS: "-Werror=unused"}
+          - {compiler: gcc, version: 14, FPM_FFLAGS: "-Werror=unused"}
           - {compiler: intel, version: '2025.0'}
           - {compiler: intel-classic, version: '2021.10'}
           - {compiler: nvidia-hpc, version: '25.1'}

--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -42,5 +42,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           # Build with FPM
-	  export FPM_FFLAGS="${{ matrix.toolchain.FFLAGS }}"
-          fpm build
+          fpm build --flag ${{ matrix.toolchain.FFLAGS }}

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -609,7 +609,7 @@ module biocfd_search
     enddo
       close(84)
 
- 1000 CONTINUE
+! 1000 CONTINUE
          WRITE(filename1,2) g
  2       FORMAT('butter_cellcount_f.',i3.3,".dat")
          OPEN(12,FILE=filename1,FORM='formatted')
@@ -2534,8 +2534,8 @@ block(g)%fluidCellCount = flcnt
        !print*,block(b_blk_no)%cpy_x_start_mv,block(b_blk_no)%cpy_x_end_mv
        !print*,block(b_blk_no)%cpy_y_start_mv,block(b_blk_no)%cpy_y_end_mv
         OPEN(UNIT=12,FILE='log.dat',STATUS='unknown',access='append')
- 11     FORMAT(2F13.5)
- 111     FORMAT(6I6)
+        ! 11 FORMAT(2F13.5)
+        ! 111  FORMAT(6I6)
         block(b_blk_no)%u=0
         block(b_blk_no)%v=0
         block(b_blk_no)%w=0


### PR DESCRIPTION
This PR makes it so the ci errors out if anything is picked up as unused by the gfortran compiler.