### PR TITLE
Remove xstart, xend, ystart, yend, zstart, zend from Blocks

### DIFF
--- a/src/ReadInput.f90
+++ b/src/ReadInput.f90
@@ -13,6 +13,10 @@ module biocfd_read_input
       SUBROUTINE readInput
        INTEGER (int64) :: i, j , k , g, nx_var, ny_var, nz_var
         CHARACTER(len=160)  :: filename1
+       ! MB: Temporary variables added, to separate them out from type Blocks. Kept until
+       !     not dependent on diff for checking code changes don't break code
+       !     Variables removed from Blocks 'xstart, xend, ystart, yend, zstart, zend'
+       REAL(dp) :: xs_temp,xe_temp,ys_temp,ye_temp,zs_temp,ze_temp
 
         OPEN(60, FILE = 'inputdata', FORM = 'formatted')
         READ(60,*) nblocks, intflines,  &
@@ -130,17 +134,9 @@ module biocfd_read_input
         OPEN(51, FILE = 'block_details.dat', FORM = 'formatted')
        DO i=1,nblocks
 
-        read(51, *) block(i)%xstart, block(i)%xend, &
-                    block(i)%ystart, block(i)%yend, &
-                    block(i)%zstart, block(i)%zend, &
+        read(51, *) xs_temp,xe_temp,ys_temp,ye_temp,zs_temp,ze_temp,&
                     block(i)%nx, block(i)%ny, block(i)%nz, &
                     block(i)%dx, block(i)%dy, block(i)%dz
-        block(i)%xstart= block(i)%xstart* 0.001_dp
-        block(i)%xend=  block(i)%xend*0.001_dp
-        block(i)%ystart= block(i)%ystart*0.001_dp
-        block(i)%yend=block(i)%yend*0.001_dp
-        block(i)%zstart=block(i)%zstart*0.001_dp
-        block(i)%zend=block(i)%zend*0.001_dp
        END DO
        CLOSE(51)
         print*,'after allocation'
@@ -194,10 +190,9 @@ module biocfd_read_input
 
          DO i=1,nblocks
         print *,'For block blockno,xstart,xend,ystart,yend,nx,ny,dx,dy:',&
-                   i, block(i)%xstart, block(i)%xend, &
-                   block(i)%ystart, block(i)%yend, &
-                   block(i)%zstart, block(i)%zend, &
-                   block(i)%nx, block(i)%ny,block(i)%nz, block(i)%dx, block(i)%dy,block(i)%dz
+             i, xs_temp*0.001_dp,xe_temp*0.001_dp,ys_temp*0.001_dp,ye_temp*0.001_dp,&
+             zs_temp*0.001_dp,ze_temp*0.001_dp,&
+              block(i)%nx, block(i)%ny,block(i)%nz, block(i)%dx, block(i)%dy,block(i)%dz
          END DO
 
 

--- a/src/ReadInput.f90
+++ b/src/ReadInput.f90
@@ -16,7 +16,8 @@ module biocfd_read_input
        ! MB: Temporary variables added, to separate them out from type Blocks. Kept until
        !     not dependent on diff for checking code changes don't break code
        !     Variables removed from Blocks 'xstart, xend, ystart, yend, zstart, zend'
-       REAL(dp) :: xs_temp,xe_temp,ys_temp,ye_temp,zs_temp,ze_temp
+       REAL(dp),ALLOCATABLE,DIMENSION(:) :: xstart_temp,xend_temp,&
+       ystart_temp,yend_temp,zstart_temp,zend_temp
 
         OPEN(60, FILE = 'inputdata', FORM = 'formatted')
         READ(60,*) nblocks, intflines,  &
@@ -28,7 +29,9 @@ module biocfd_read_input
         CLOSE(60)
         allocate(Blocks :: block(nblocks))
         allocate(Interfaces :: intfr(intflines))
-
+        allocate(xstart_temp(nblocks),xend_temp(nblocks),&
+        ystart_temp(nblocks),yend_temp(nblocks),&
+        zstart_temp(nblocks),zend_temp(nblocks))
         OPEN(77, FILE = 'body_search.dat', FORM = 'formatted')
         DO g=1,nblocks
                 READ(77,*) block(g)%i_startSearch, block(g)%i_endSearch, &
@@ -134,7 +137,8 @@ module biocfd_read_input
         OPEN(51, FILE = 'block_details.dat', FORM = 'formatted')
        DO i=1,nblocks
 
-        read(51, *) xs_temp,xe_temp,ys_temp,ye_temp,zs_temp,ze_temp,&
+        read(51, *) xs_temp(i),xe_temp(i),ys_temp(i),&
+                    ye_temp(i),zs_temp(i),ze_temp(i),&
                     block(i)%nx, block(i)%ny, block(i)%nz, &
                     block(i)%dx, block(i)%dy, block(i)%dz
        END DO
@@ -190,8 +194,9 @@ module biocfd_read_input
 
          DO i=1,nblocks
         print *,'For block blockno,xstart,xend,ystart,yend,nx,ny,dx,dy:',&
-             i, xs_temp*0.001_dp,xe_temp*0.001_dp,ys_temp*0.001_dp,ye_temp*0.001_dp,&
-             zs_temp*0.001_dp,ze_temp*0.001_dp,&
+             i, xs_temp(i)*0.001_dp,xe_temp(i)*0.001_dp,&
+             ys_temp(i)*0.001_dp,ye_temp(i)*0.001_dp,&
+             zs_temp(i)*0.001_dp,ze_temp(i)*0.001_dp,&
               block(i)%nx, block(i)%ny,block(i)%nz, block(i)%dx, block(i)%dy,block(i)%dz
          END DO
 

--- a/src/ReadInput.f90
+++ b/src/ReadInput.f90
@@ -137,8 +137,8 @@ module biocfd_read_input
         OPEN(51, FILE = 'block_details.dat', FORM = 'formatted')
        DO i=1,nblocks
 
-        read(51, *) xs_temp(i),xe_temp(i),ys_temp(i),&
-                    ye_temp(i),zs_temp(i),ze_temp(i),&
+        read(51, *) xstart_temp(i),xend_temp(i),ystart_temp(i),&
+                    yend_temp(i),zstart_temp(i),zend_temp(i),&
                     block(i)%nx, block(i)%ny, block(i)%nz, &
                     block(i)%dx, block(i)%dy, block(i)%dz
        END DO
@@ -194,9 +194,9 @@ module biocfd_read_input
 
          DO i=1,nblocks
         print *,'For block blockno,xstart,xend,ystart,yend,nx,ny,dx,dy:',&
-             i, xs_temp(i)*0.001_dp,xe_temp(i)*0.001_dp,&
-             ys_temp(i)*0.001_dp,ye_temp(i)*0.001_dp,&
-             zs_temp(i)*0.001_dp,ze_temp(i)*0.001_dp,&
+             i, xstart_temp(i)*0.001_dp,xend_temp(i)*0.001_dp,&
+             ystart_temp(i)*0.001_dp,yend_temp(i)*0.001_dp,&
+             zstart_temp(i)*0.001_dp,zend_temp(i)*0.001_dp,&
               block(i)%nx, block(i)%ny,block(i)%nz, block(i)%dx, block(i)%dy,block(i)%dz
          END DO
 

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -28,8 +28,8 @@ MODULE global
         INTEGER (int64) ::nblocks, intflines
 
         type Blocks
-        REAL(dp) :: xstart, xend, ystart, yend, zstart, zend, dx,dy, dz, ypth1, ypth2, &
-                    xpth1, xpth2, xchg,ychg, yt, ydot, yddot, bfreq, yamp, xt, xdot, xddot
+           REAL(dp) ::  dx,dy, dz,ypth1, ypth2, xpth1, xpth2, xchg,ychg, yt, ydot, yddot,&
+                bfreq, yamp, xt, xdot, xddot
         REAL(dp) :: derr1,derr2,derrStdSt,a0
         REAL(dp) :: xshift, yshift, zshift, gx_shift, gy_shift,gz_shift
         INTEGER (int64):: nx, ny, nz


### PR DESCRIPTION
This PR removes xstart, xend, ystart, yend, zstart, zend from Blocks, as they are unused.