### PR TITLE
Add first test of Search.f90

### DIFF
--- a/test/main.f90
+++ b/test/main.f90
@@ -1,12 +1,12 @@
 program tester
   use, intrinsic :: iso_fortran_env, only : error_unit
   use testdrive, only : run_testsuite
-  use test_demo, only : collect_demo
+  use test_search, only : collect_search
   implicit none
   integer :: stat
 
   stat = 0
-  call run_testsuite(collect_demo, error_unit, stat)
+  call run_testsuite(collect_search, error_unit, stat)
 
   if (stat > 0) then
     write(error_unit, '(i0, 1x, a)') stat, "test(s) failed!"

--- a/test/test_search.f90
+++ b/test/test_search.f90
@@ -1,5 +1,5 @@
 module test_search
-  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use, intrinsic :: iso_fortran_env, only: dp => real64, int64
   use testdrive, only : error_type, unittest_type, new_unittest, check
   implicit none
   private
@@ -19,7 +19,7 @@ contains
 
   subroutine test_find_dist_node(error)
     use biocfd_search, only : findDistnode
-    use global
+    use global, only : block, blk_start, nblocks
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
 

--- a/test/test_search.f90
+++ b/test/test_search.f90
@@ -1,4 +1,5 @@
 module test_search
+  use, intrinsic :: iso_fortran_env, only: dp => real64
   use testdrive, only : error_type, unittest_type, new_unittest, check
   implicit none
   private
@@ -17,9 +18,26 @@ contains
 
 
   subroutine test_find_dist_node(error)
+    use biocfd_search, only : findDistnode
+    use global
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
 
-    call check(error, "This is a valid example", "This is a valid example")
+    integer(int64) :: expected
+
+    ! Setup the required block variables
+    blk_start = 1
+    nblocks = 1
+    allocate(block(nblocks))
+    block(1)%ibnodes = 6
+    block(1)%ibNodeId = [51, 51, 51, 51, 51, 51]
+    block(1)%xnode = [0, -7, -4, 1, -10, 8]
+    block(1)%ynode = [0, -7, -4, 1, -10, 8]
+    block(1)%znode = [0, -7, -4, 1, -10, 8]
+
+    call findDistnode
+    expected = 6
+    call check(error, block(1)%mk, expected)
+    if (allocated(error)) return
   end subroutine test_find_dist_node
 end module test_search

--- a/test/test_search.f90
+++ b/test/test_search.f90
@@ -1,25 +1,25 @@
-module test_demo
+module test_search
   use testdrive, only : error_type, unittest_type, new_unittest, check
   implicit none
   private
 
-  public :: collect_demo
+  public :: collect_search
 
 contains
 
   !> Collect all exported unit tests
-  subroutine collect_demo(testsuite)
+  subroutine collect_search(testsuite)
     !> Collection of tests
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
-    testsuite = [new_unittest("substitute", test_substitute)]
-  end subroutine collect_demo
+    testsuite = [new_unittest("find_dist_node", test_find_dist_node)]
+  end subroutine collect_search
 
-  !> Check substitution of a single line
-  subroutine test_substitute(error)
+
+  subroutine test_find_dist_node(error)
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
 
     call check(error, "This is a valid example", "This is a valid example")
-  end subroutine test_substitute
-end module test_demo
+  end subroutine test_find_dist_node
+end module test_search


### PR DESCRIPTION
First largely dummy test of the `findDistnode` subroutine. However, see #21 about unusual behaviour of the subroutine.