### PR TITLE
Convert tabs to spaces in NavierStokes.f90

### DIFF
--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -27,7 +27,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         toolchain:
-          - {compiler: gcc, version: 14, FPM_FFLAGS: "-Werror=unused --coverage"}
+          - compiler: gcc
+            version: 14
+            FPM_FFLAGS: "-Werror=unused --coverage -pedantic-errors"
           - {compiler: intel, version: '2025.0'}
           - {compiler: intel-classic, version: '2021.10'}
           - {compiler: nvidia-hpc, version: '25.1'}

--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -9,9 +9,9 @@ module biocfd_navier_stokes
 
 contains
 
-	SUBROUTINE non_uni_coeff
-	INTEGER  (dp) :: i, j, k, g, nx_var, ny_var, nz_var
-	REAL (dp)   :: f_1, f_2, f_3, f_4, f_5, f_6, f_7, f_8,                             &
+       SUBROUTINE non_uni_coeff
+       INTEGER  (dp) :: i, j, k, g, nx_var, ny_var, nz_var
+       REAL (dp)   :: f_1, f_2, f_3, f_4, f_5, f_6, f_7, f_8,                             &
                          s51, s52, s53, s54, s55, s56, s57, s61, s62, s63, s64, s65, s66, s67,  &
                          s71, s72, s73, s74, s75, s76, s81, s82, s83, s84, s85, s86, s91, s92,  &
                          s93, s94, s95, s96, s97, s101, s102, s103, s104, s105, s106, s107,     &
@@ -61,607 +61,607 @@ contains
              block(g)%ca4_wv(nz_var+2), block(g)%ca5_wv(nz_var+2), block(g)%ca6_wv(nz_var+2), &
              block(g)%ck1_wv(nz_var+2), block(g)%ck2_wv(nz_var+2), block(g)%ck3_wv(nz_var+2), &
              block(g)%ck4_wv(nz_var+2), block(g)%ck5_wv(nz_var+2), block(g)%ck6_wv(nz_var+2))
-	END DO
+       END DO
 
         DO g=1,nblocks
         nx_var=block(g)%nx
         ny_var=block(g)%ny
         nz_var=block(g)%nz
-	do i=2,nx_var
-	theta_1=block(g)%deltax(i)/block(g)%deltax(i-1)
-	theta_2=block(g)%deltax(i+1)/block(g)%deltax(i)
-	theta_3=block(g)%deltax(i+2)/block(g)%deltax(i+1)
+       do i=2,nx_var
+       theta_1=block(g)%deltax(i)/block(g)%deltax(i-1)
+       theta_2=block(g)%deltax(i+1)/block(g)%deltax(i)
+       theta_3=block(g)%deltax(i+2)/block(g)%deltax(i+1)
 
         f_1=theta_3
         f_2=2.0_dp*theta_3+theta_3**2.0_dp
-	f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-	f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-	f_5=1.0_dp/(theta_1*theta_2)
-	f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-	f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
+       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
+       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
+       f_5=1.0_dp/(theta_1*theta_2)
+       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
+       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
         f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
             ((theta_1**4.0_dp)*(theta_2**4.0_dp))
 
-	s51=-1.0_dp/(theta_2**4.0_dp)
-	s52=f_4
-	s53=f_4
-	s54=s51
-	s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-	s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-	s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+       s51=-1.0_dp/(theta_2**4.0_dp)
+       s52=f_4
+       s53=f_4
+       s54=s51
+       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
+       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
+       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
 
-	s61=-1.0_dp
-	s62=f_8
-	s63=f_8
-	s64=-1.0
-	s65=(f_5+f_8)
-	s66=(f_8-f_6)
-	s67=(f_7+f_8)
+       s61=-1.0_dp
+       s62=f_8
+       s63=f_8
+       s64=-1.0
+       s65=(f_5+f_8)
+       s66=(f_8-f_6)
+       s67=(f_7+f_8)
 
-	s71=-1.0_dp
-	s72=(1.0_dp+f_4)
-	s73=f_4
-	s74=(f_4-f_1)
-	s75=(f_4-f_2)
-	s76=(f_4-f_3)
+       s71=-1.0_dp
+       s72=(1.0_dp+f_4)
+       s73=f_4
+       s74=(f_4-f_1)
+       s75=(f_4-f_2)
+       s76=(f_4-f_3)
 
-	s81=-1.0_dp/(theta_2**4.0_dp)
-	s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-	s83=f_8
-	s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-	s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-	s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
+       s81=-1.0_dp/(theta_2**4.0_dp)
+       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
+       s83=f_8
+       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
+       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
+       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
 
-	s91=-s66*s51
-	s92=s56*s61
-	s93=-(s54*s66+s56*s62)
-	s94=(s56*s64+s66*s52)
-	s95=(s56*s63-s66*s53)
-	s96=(s56*s65-s66*s55)
-	s97=(s56*s67-s66*s57)
+       s91=-s66*s51
+       s92=s56*s61
+       s93=-(s54*s66+s56*s62)
+       s94=(s56*s64+s66*s52)
+       s95=(s56*s63-s66*s53)
+       s96=(s56*s65-s66*s55)
+       s97=(s56*s67-s66*s57)
 
-	s101=-s85*s71
-	s102=-s85*s72
-	s103=s75*s81
-	s104=s75*s82
-	s105=(s75*s83-s85*s73)
-	s106=(s75*s84-s85*s74)
-	s107=(s75*s86-s85*s76)
+       s101=-s85*s71
+       s102=-s85*s72
+       s103=s75*s81
+       s104=s75*s82
+       s105=(s75*s83-s85*s73)
+       s106=(s75*s84-s85*s74)
+       s107=(s75*s86-s85*s76)
 
-	block(g)%ca1_uu(i)=(s97*s101-s107*s91)
-	block(g)%ca2_uu(i)=(s97*s102+s107*s93)
-	block(g)%ca3_uu(i)=(s95*s107-s105*s97)
-	block(g)%ca4_uu(i)=(s94*s107+s104*s97)
-	block(g)%ca5_uu(i)=(s97*s103-s107*s92)
-	block(g)%ca6_uu(i)=(s97*s106-s107*s96)
+       block(g)%ca1_uu(i)=(s97*s101-s107*s91)
+       block(g)%ca2_uu(i)=(s97*s102+s107*s93)
+       block(g)%ca3_uu(i)=(s95*s107-s105*s97)
+       block(g)%ca4_uu(i)=(s94*s107+s104*s97)
+       block(g)%ca5_uu(i)=(s97*s103-s107*s92)
+       block(g)%ca6_uu(i)=(s97*s106-s107*s96)
 
-	ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-	ak_3=(1.0_dp+theta_1)
-	ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-	ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-	ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
+       ak_3=(1.0_dp+theta_1)
+       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
+       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
+       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
 
-	block(g)%ck1_uu(i)=ak_3
-	block(g)%ck2_uu(i)=-ak_4
-	block(g)%ck3_uu(i)=(ak_1+ak_2)
-	block(g)%ck4_uu(i)=-ak_5
-	block(g)%ck5_uu(i)=ak_6
-	block(g)%ck6_uu(i)=ak_7
-	enddo
+       block(g)%ck1_uu(i)=ak_3
+       block(g)%ck2_uu(i)=-ak_4
+       block(g)%ck3_uu(i)=(ak_1+ak_2)
+       block(g)%ck4_uu(i)=-ak_5
+       block(g)%ck5_uu(i)=ak_6
+       block(g)%ck6_uu(i)=ak_7
+       enddo
         ENDDO
         DO g=1,nblocks
         nx_var=block(g)%nx
         ny_var=block(g)%ny
         nz_var=block(g)%nz
-	do j=2,ny_var
-	theta_1=block(g)%deltay(j)/block(g)%deltay(j-1)
-	theta_2=block(g)%deltay(j+1)/block(g)%deltay(j)
-	theta_3=block(g)%deltay(j+2)/block(g)%deltay(j+1)
+       do j=2,ny_var
+       theta_1=block(g)%deltay(j)/block(g)%deltay(j-1)
+       theta_2=block(g)%deltay(j+1)/block(g)%deltay(j)
+       theta_3=block(g)%deltay(j+2)/block(g)%deltay(j+1)
 
-	f_1=theta_3
-	f_2=2.0_dp*theta_3+theta_3**2.0_dp
-	f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-	f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-	f_5=1.0_dp/(theta_1*theta_2)
-	f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-	f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
+       f_1=theta_3
+       f_2=2.0_dp*theta_3+theta_3**2.0_dp
+       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
+       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
+       f_5=1.0_dp/(theta_1*theta_2)
+       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
+       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
         f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
             ((theta_1**4.0_dp)*(theta_2**4.0_dp))
 
-	s51=-1.0_dp/(theta_2**4.0_dp)
-	s52=f_4
-	s53=f_4
-	s54=s51
-	s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-	s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-	s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+       s51=-1.0_dp/(theta_2**4.0_dp)
+       s52=f_4
+       s53=f_4
+       s54=s51
+       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
+       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
+       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
 
-	s61=-1.0_dp
-	s62=f_8
-	s63=f_8
-	s64=-1.0_dp
-	s65=(f_5+f_8)
-	s66=(f_8-f_6)
-	s67=(f_7+f_8)
+       s61=-1.0_dp
+       s62=f_8
+       s63=f_8
+       s64=-1.0_dp
+       s65=(f_5+f_8)
+       s66=(f_8-f_6)
+       s67=(f_7+f_8)
 
-	s71=-1.0_dp
-	s72=(1.0_dp+f_4)
-	s73=f_4
-	s74=(f_4-f_1)
-	s75=(f_4-f_2)
-	s76=(f_4-f_3)
+       s71=-1.0_dp
+       s72=(1.0_dp+f_4)
+       s73=f_4
+       s74=(f_4-f_1)
+       s75=(f_4-f_2)
+       s76=(f_4-f_3)
 
-	s81=-1.0_dp/(theta_2**4.0_dp)
-	s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-	s83=f_8
-	s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-	s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-	s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
+       s81=-1.0_dp/(theta_2**4.0_dp)
+       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
+       s83=f_8
+       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
+       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
+       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
 
-	s91=-s66*s51
-	s92=s56*s61
-	s93=-(s54*s66+s56*s62)
-	s94=(s56*s64+s66*s52)
-	s95=(s56*s63-s66*s53)
-	s96=(s56*s65-s66*s55)
-	s97=(s56*s67-s66*s57)
+       s91=-s66*s51
+       s92=s56*s61
+       s93=-(s54*s66+s56*s62)
+       s94=(s56*s64+s66*s52)
+       s95=(s56*s63-s66*s53)
+       s96=(s56*s65-s66*s55)
+       s97=(s56*s67-s66*s57)
 
-	s101=-s85*s71
-	s102=-s85*s72
-	s103=s75*s81
-	s104=s75*s82
-	s105=(s75*s83-s85*s73)
-	s106=(s75*s84-s85*s74)
-	s107=(s75*s86-s85*s76)
+       s101=-s85*s71
+       s102=-s85*s72
+       s103=s75*s81
+       s104=s75*s82
+       s105=(s75*s83-s85*s73)
+       s106=(s75*s84-s85*s74)
+       s107=(s75*s86-s85*s76)
 
-	block(g)%ca1_vv(j)=(s97*s101-s107*s91)
-	block(g)%ca2_vv(j)=(s97*s102+s107*s93)
-	block(g)%ca3_vv(j)=(s95*s107-s105*s97)
-	block(g)%ca4_vv(j)=(s94*s107+s104*s97)
-	block(g)%ca5_vv(j)=(s97*s103-s107*s92)
-	block(g)%ca6_vv(j)=(s97*s106-s107*s96)
+       block(g)%ca1_vv(j)=(s97*s101-s107*s91)
+       block(g)%ca2_vv(j)=(s97*s102+s107*s93)
+       block(g)%ca3_vv(j)=(s95*s107-s105*s97)
+       block(g)%ca4_vv(j)=(s94*s107+s104*s97)
+       block(g)%ca5_vv(j)=(s97*s103-s107*s92)
+       block(g)%ca6_vv(j)=(s97*s106-s107*s96)
 
-	ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-	ak_3=(1.0_dp+theta_1)
-	ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-	ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-	ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
+       ak_3=(1.0_dp+theta_1)
+       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
+       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
+       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
 
-	block(g)%ck1_vv(j)=ak_3
-	block(g)%ck2_vv(j)=-ak_4
-	block(g)%ck3_vv(j)=(ak_1+ak_2)
-	block(g)%ck4_vv(j)=-ak_5
-	block(g)%ck5_vv(j)=ak_6
-	block(g)%ck6_vv(j)=ak_7
-	enddo
-        ENDDO
-
-        DO g=1,nblocks
-        nx_var=block(g)%nx
-        ny_var=block(g)%ny
-        nz_var=block(g)%nz
-	do k=2,nz_var
-	theta_1=block(g)%deltaz(k)/block(g)%deltaz(k-1)
-	theta_2=block(g)%deltaz(k+1)/block(g)%deltaz(k)
-	theta_3=block(g)%deltaz(k+2)/block(g)%deltaz(k+1)
-
-	f_1=theta_3
-	f_2=2.0_dp*theta_3+theta_3**2.0_dp
-	f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-	f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-	f_5=1.0_dp/(theta_1*theta_2)
-	f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-	f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
-        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
-            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
-
-	s51=-1.0_dp/(theta_2**4.0_dp)
-	s52=f_4
-	s53=f_4
-	s54=s51
-	s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-	s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-	s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
-
-	s61=-1.0_dp
-	s62=f_8
-	s63=f_8
-	s64=-1.0_dp
-	s65=(f_5+f_8)
-	s66=(f_8-f_6)
-	s67=(f_7+f_8)
-
-	s71=-1.0_dp
-	s72=(1.0_dp+f_4)
-	s73=f_4
-	s74=(f_4-f_1)
-	s75=(f_4-f_2)
-	s76=(f_4-f_3)
-
-	s81=-1.0_dp/(theta_2**4.0_dp)
-	s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-	s83=f_8
-	s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-	s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-	s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
-
-	s91=-s66*s51
-	s92=s56*s61
-	s93=-(s54*s66+s56*s62)
-	s94=(s56*s64+s66*s52)
-	s95=(s56*s63-s66*s53)
-	s96=(s56*s65-s66*s55)
-	s97=(s56*s67-s66*s57)
-
-	s101=-s85*s71
-	s102=-s85*s72
-	s103=s75*s81
-	s104=s75*s82
-	s105=(s75*s83-s85*s73)
-	s106=(s75*s84-s85*s74)
-	s107=(s75*s86-s85*s76)
-
-	block(g)%ca1_ww(k)=(s97*s101-s107*s91)
-	block(g)%ca2_ww(k)=(s97*s102+s107*s93)
-	block(g)%ca3_ww(k)=(s95*s107-s105*s97)
-	block(g)%ca4_ww(k)=(s94*s107+s104*s97)
-	block(g)%ca5_ww(k)=(s97*s103-s107*s92)
-	block(g)%ca6_ww(k)=(s97*s106-s107*s96)
-
-	ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-	ak_3=(1.0_dp+theta_1)
-	ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-	ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-	ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-
-	block(g)%ck1_ww(k)=ak_3
-	block(g)%ck2_ww(k)=-ak_4
-	block(g)%ck3_ww(k)=(ak_1+ak_2)
-	block(g)%ck4_ww(k)=-ak_5
-	block(g)%ck5_ww(k)=ak_6
-	block(g)%ck6_ww(k)=ak_7
-	enddo
-        END DO
-
-        DO g=1,nblocks
-        nx_var=block(g)%nx
-        ny_var=block(g)%ny
-        nz_var=block(g)%nz
-	do i=2,nx_var
-	if(i==2)then
-	tmp_dx1=block(g)%deltax(i-1)
-	else
-	tmp_dx1=0.5_dp*(block(g)%deltax(i-1)+block(g)%deltax(i-2))
-	endif
-	tmp_dx2=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i-1))
-	tmp_dx3=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i+1))
-	tmp_dx4=0.5_dp*(block(g)%deltax(i+1)+block(g)%deltax(i+2))
-
-	theta_1=tmp_dx2/tmp_dx1
-	theta_2=tmp_dx3/tmp_dx2
-	theta_3=tmp_dx4/tmp_dx3
-
-	f_1=theta_3
-	f_2=2.0_dp*theta_3+theta_3**2.0_dp
-	f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-	f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-	f_5=1.0_dp/(theta_1*theta_2)
-	f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-	f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
-        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
-            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
-
-	s51=-1.0_dp/(theta_2**4.0_dp)
-	s52=f_4
-	s53=f_4
-	s54=s51
-	s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-	s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-	s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
-
-	s61=-1.0_dp
-	s62=f_8
-	s63=f_8
-	s64=-1.0_dp
-	s65=(f_5+f_8)
-	s66=(f_8-f_6)
-	s67=(f_7+f_8)
-
-	s71=-1.0_dp
-	s72=(1.0_dp+f_4)
-	s73=f_4
-	s74=(f_4-f_1)
-	s75=(f_4-f_2)
-	s76=(f_4-f_3)
-
-	s81=-1.0_dp/(theta_2**4.0_dp)
-	s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-	s83=f_8
-	s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-	s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-	s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
-
-	s91=-s66*s51
-	s92=s56*s61
-	s93=-(s54*s66+s56*s62)
-	s94=(s56*s64+s66*s52)
-	s95=(s56*s63-s66*s53)
-	s96=(s56*s65-s66*s55)
-	s97=(s56*s67-s66*s57)
-
-	s101=-s85*s71
-	s102=-s85*s72
-	s103=s75*s81
-	s104=s75*s82
-	s105=(s75*s83-s85*s73)
-	s106=(s75*s84-s85*s74)
-	s107=(s75*s86-s85*s76)
-
-	block(g)%ca1_uv(i)=(s97*s101-s107*s91)
-	block(g)%ca1_uw(i)=block(g)%ca1_uv(i)
-	block(g)%ca2_uv(i)=(s97*s102+s107*s93)
-	block(g)%ca2_uw(i)=block(g)%ca2_uv(i)
-	block(g)%ca3_uv(i)=(s95*s107-s105*s97)
-	block(g)%ca3_uw(i)=block(g)%ca3_uv(i)
-	block(g)%ca4_uv(i)=(s94*s107+s104*s97)
-	block(g)%ca4_uw(i)=block(g)%ca4_uv(i)
-	block(g)%ca5_uv(i)=(s97*s103-s107*s92)
-	block(g)%ca5_uw(i)=block(g)%ca5_uv(i)
-	block(g)%ca6_uv(i)=(s97*s106-s107*s96)
-	block(g)%ca6_uw(i)=block(g)%ca6_uv(i)
-
-	ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-	ak_3=(1.0_dp+theta_1)
-	ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-	ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-	ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-
-	block(g)%ck1_uv(i)=ak_3
-	block(g)%ck1_uw(i)=block(g)%ck1_uv(i)
-	block(g)%ck2_uv(i)=-ak_4
-	block(g)%ck2_uw(i)=block(g)%ck2_uv(i)
-	block(g)%ck3_uv(i)=(ak_1+ak_2)
-	block(g)%ck3_uw(i)=block(g)%ck3_uv(i)
-	block(g)%ck4_uv(i)=-ak_5
-	block(g)%ck4_uw(i)=block(g)%ck4_uv(i)
-	block(g)%ck5_uv(i)=ak_6
-	block(g)%ck5_uw(i)=block(g)%ck5_uv(i)
-	block(g)%ck6_uv(i)=ak_7
-	block(g)%ck6_uw(i)=block(g)%ck6_uv(i)
-	enddo
-        END DO
-
-        DO g=1,nblocks
-        nx_var=block(g)%nx
-        ny_var=block(g)%ny
-        nz_var=block(g)%nz
-	do j=2,ny_var
-	if(j==2)then
-	tmp_dy1=block(g)%deltay(j-1)
-	else
-	tmp_dy1=0.5_dp*(block(g)%deltay(j-1)+block(g)%deltay(j-2))
-	endif
-	tmp_dy2=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j-1))
-	tmp_dy3=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j+1))
-	tmp_dy4=0.5_dp*(block(g)%deltay(j+1)+block(g)%deltay(j+2))
-
-	theta_1=tmp_dy2/tmp_dy1
-	theta_2=tmp_dy3/tmp_dy2
-	theta_3=tmp_dy4/tmp_dy3
-
-	f_1=theta_3
-	f_2=2.0_dp*theta_3+theta_3**2.0_dp
-	f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-	f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-	f_5=1.0_dp/(theta_1*theta_2)
-	f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-	f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
-        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
-            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
-
-	s51=-1.0_dp/(theta_2**4.0_dp)
-	s52=f_4
-	s53=f_4
-	s54=s51
-	s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-	s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-	s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
-
-	s61=-1.0_dp
-	s62=f_8
-	s63=f_8
-	s64=-1.0_dp
-	s65=(f_5+f_8)
-	s66=(f_8-f_6)
-	s67=(f_7+f_8)
-
-	s71=-1.0_dp
-	s72=(1.0_dp+f_4)
-	s73=f_4
-	s74=(f_4-f_1)
-	s75=(f_4-f_2)
-	s76=(f_4-f_3)
-
-	s81=-1.0_dp/(theta_2**4.0_dp)
-	s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-	s83=f_8
-	s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-	s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-	s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
-
-	s91=-s66*s51
-	s92=s56*s61
-	s93=-(s54*s66+s56*s62)
-	s94=(s56*s64+s66*s52)
-	s95=(s56*s63-s66*s53)
-	s96=(s56*s65-s66*s55)
-	s97=(s56*s67-s66*s57)
-
-	s101=-s85*s71
-	s102=-s85*s72
-	s103=s75*s81
-	s104=s75*s82
-	s105=(s75*s83-s85*s73)
-	s106=(s75*s84-s85*s74)
-	s107=(s75*s86-s85*s76)
-
-	block(g)%ca1_vu(j)=(s97*s101-s107*s91)
-	block(g)%ca1_vw(j)=block(g)%ca1_vu(j)
-	block(g)%ca2_vu(j)=(s97*s102+s107*s93)
-	block(g)%ca2_vw(j)=block(g)%ca2_vu(j)
-	block(g)%ca3_vu(j)=(s95*s107-s105*s97)
-	block(g)%ca3_vw(j)=block(g)%ca3_vu(j)
-	block(g)%ca4_vu(j)=(s94*s107+s104*s97)
-	block(g)%ca4_vw(j)=block(g)%ca4_vu(j)
-	block(g)%ca5_vu(j)=(s97*s103-s107*s92)
-	block(g)%ca5_vw(j)=block(g)%ca5_vu(j)
-	block(g)%ca6_vu(j)=(s97*s106-s107*s96)
-	block(g)%ca6_vw(j)=block(g)%ca6_vu(j)
-
-	ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-	ak_3=(1.0_dp+theta_1)
-	ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-	ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-	ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-
-	block(g)%ck1_vu(j)=ak_3
-	block(g)%ck1_vw(j)=block(g)%ck1_vu(j)
-	block(g)%ck2_vu(j)=-ak_4
-	block(g)%ck2_vw(j)=block(g)%ck2_vu(j)
-	block(g)%ck3_vu(j)=(ak_1+ak_2)
-	block(g)%ck3_vw(j)=block(g)%ck3_vu(j)
-	block(g)%ck4_vu(j)=-ak_5
-	block(g)%ck4_vw(j)=block(g)%ck4_vu(j)
-	block(g)%ck5_vu(j)=ak_6
-	block(g)%ck5_vw(j)=block(g)%ck5_vu(j)
-	block(g)%ck6_vu(j)=ak_7
-	block(g)%ck6_vw(j)=block(g)%ck6_vu(j)
-	enddo
+       block(g)%ck1_vv(j)=ak_3
+       block(g)%ck2_vv(j)=-ak_4
+       block(g)%ck3_vv(j)=(ak_1+ak_2)
+       block(g)%ck4_vv(j)=-ak_5
+       block(g)%ck5_vv(j)=ak_6
+       block(g)%ck6_vv(j)=ak_7
+       enddo
         ENDDO
 
         DO g=1,nblocks
         nx_var=block(g)%nx
         ny_var=block(g)%ny
         nz_var=block(g)%nz
-	do k=2,nz_var
-	if(k==2)then
-	tmp_dz1=block(g)%deltaz(k-1)
-	else
-	tmp_dz1=0.5_dp*(block(g)%deltaz(k-1)+block(g)%deltaz(k-2))
-	endif
-	tmp_dz2=0.5_dp*(block(g)%deltaz(k)+block(g)%deltaz(k-1))
-	tmp_dz3=0.5_dp*(block(g)%deltaz(k)+block(g)%deltaz(k+1))
-	tmp_dz4=0.5_dp*(block(g)%deltaz(k+1)+block(g)%deltaz(k+2))
+       do k=2,nz_var
+       theta_1=block(g)%deltaz(k)/block(g)%deltaz(k-1)
+       theta_2=block(g)%deltaz(k+1)/block(g)%deltaz(k)
+       theta_3=block(g)%deltaz(k+2)/block(g)%deltaz(k+1)
 
-	theta_1=tmp_dz2/tmp_dz1
-	theta_2=tmp_dz3/tmp_dz2
-	theta_3=tmp_dz4/tmp_dz3
-
-	f_1=theta_3
-	f_2=2.0_dp*theta_3+theta_3**2.0_dp
-	f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-	f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-	f_5=1.0_dp/(theta_1*theta_2)
-	f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-	f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
+       f_1=theta_3
+       f_2=2.0_dp*theta_3+theta_3**2.0_dp
+       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
+       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
+       f_5=1.0_dp/(theta_1*theta_2)
+       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
+       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
         f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
             ((theta_1**4.0_dp)*(theta_2**4.0_dp))
 
-	s51=-1.0_dp/(theta_2**4.0_dp)
-	s52=f_4
-	s53=f_4
-	s54=s51
-	s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-	s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-	s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+       s51=-1.0_dp/(theta_2**4.0_dp)
+       s52=f_4
+       s53=f_4
+       s54=s51
+       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
+       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
+       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
 
-	s61=-1.0_dp
-	s62=f_8
-	s63=f_8
-	s64=-1.0_dp
-	s65=(f_5+f_8)
-	s66=(f_8-f_6)
-	s67=(f_7+f_8)
+       s61=-1.0_dp
+       s62=f_8
+       s63=f_8
+       s64=-1.0_dp
+       s65=(f_5+f_8)
+       s66=(f_8-f_6)
+       s67=(f_7+f_8)
 
-	s71=-1.0_dp
-	s72=(1.0_dp+f_4)
-	s73=f_4
-	s74=(f_4-f_1)
-	s75=(f_4-f_2)
-	s76=(f_4-f_3)
+       s71=-1.0_dp
+       s72=(1.0_dp+f_4)
+       s73=f_4
+       s74=(f_4-f_1)
+       s75=(f_4-f_2)
+       s76=(f_4-f_3)
 
-	s81=-1.0_dp/(theta_2**4.0_dp)
-	s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-	s83=f_8
-	s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-	s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-	s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
+       s81=-1.0_dp/(theta_2**4.0_dp)
+       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
+       s83=f_8
+       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
+       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
+       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
 
-	s91=-s66*s51
-	s92=s56*s61
-	s93=-(s54*s66+s56*s62)
-	s94=(s56*s64+s66*s52)
-	s95=(s56*s63-s66*s53)
-	s96=(s56*s65-s66*s55)
-	s97=(s56*s67-s66*s57)
+       s91=-s66*s51
+       s92=s56*s61
+       s93=-(s54*s66+s56*s62)
+       s94=(s56*s64+s66*s52)
+       s95=(s56*s63-s66*s53)
+       s96=(s56*s65-s66*s55)
+       s97=(s56*s67-s66*s57)
 
-	s101=-s85*s71
-	s102=-s85*s72
-	s103=s75*s81
-	s104=s75*s82
-	s105=(s75*s83-s85*s73)
-	s106=(s75*s84-s85*s74)
-	s107=(s75*s86-s85*s76)
+       s101=-s85*s71
+       s102=-s85*s72
+       s103=s75*s81
+       s104=s75*s82
+       s105=(s75*s83-s85*s73)
+       s106=(s75*s84-s85*s74)
+       s107=(s75*s86-s85*s76)
 
-	block(g)%ca1_wu(k)=(s97*s101-s107*s91)
-	block(g)%ca1_wv(k)=block(g)%ca1_wu(k)
-	block(g)%ca2_wu(k)=(s97*s102+s107*s93)
-	block(g)%ca2_wv(k)=block(g)%ca2_wu(k)
-	block(g)%ca3_wu(k)=(s95*s107-s105*s97)
-	block(g)%ca3_wv(k)=block(g)%ca3_wu(k)
-	block(g)%ca4_wu(k)=(s94*s107+s104*s97)
-	block(g)%ca4_wv(k)=block(g)%ca4_wu(k)
-	block(g)%ca5_wu(k)=(s97*s103-s107*s92)
-	block(g)%ca5_wv(k)=block(g)%ca5_wu(k)
-	block(g)%ca6_wu(k)=(s97*s106-s107*s96)
-	block(g)%ca6_wv(k)=block(g)%ca6_wu(k)
+       block(g)%ca1_ww(k)=(s97*s101-s107*s91)
+       block(g)%ca2_ww(k)=(s97*s102+s107*s93)
+       block(g)%ca3_ww(k)=(s95*s107-s105*s97)
+       block(g)%ca4_ww(k)=(s94*s107+s104*s97)
+       block(g)%ca5_ww(k)=(s97*s103-s107*s92)
+       block(g)%ca6_ww(k)=(s97*s106-s107*s96)
 
-	ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-	ak_3=(1.0_dp+theta_1)
-	ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-	ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-	ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-	ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
+       ak_3=(1.0_dp+theta_1)
+       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
+       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
+       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
 
-	block(g)%ck1_wu(k)=ak_3
-	block(g)%ck1_wv(k)=block(g)%ck1_wu(k)
-	block(g)%ck2_wu(k)=-ak_4
-	block(g)%ck2_wv(k)=block(g)%ck2_wu(k)
-	block(g)%ck3_wu(k)=(ak_1+ak_2)
-	block(g)%ck3_wv(k)=block(g)%ck3_wu(k)
-	block(g)%ck4_wu(k)=-ak_5
-	block(g)%ck4_wv(k)=block(g)%ck4_wu(k)
-	block(g)%ck5_wu(k)=ak_6
-	block(g)%ck5_wv(k)=block(g)%ck5_wu(k)
-	block(g)%ck6_wu(k)=ak_7
-	block(g)%ck6_wv(k)=block(g)%ck6_wu(k)
-	enddo
+       block(g)%ck1_ww(k)=ak_3
+       block(g)%ck2_ww(k)=-ak_4
+       block(g)%ck3_ww(k)=(ak_1+ak_2)
+       block(g)%ck4_ww(k)=-ak_5
+       block(g)%ck5_ww(k)=ak_6
+       block(g)%ck6_ww(k)=ak_7
+       enddo
         END DO
 
-	write(*,*)'leaving non_uni_coeff'
+        DO g=1,nblocks
+        nx_var=block(g)%nx
+        ny_var=block(g)%ny
+        nz_var=block(g)%nz
+       do i=2,nx_var
+       if(i==2)then
+       tmp_dx1=block(g)%deltax(i-1)
+       else
+       tmp_dx1=0.5_dp*(block(g)%deltax(i-1)+block(g)%deltax(i-2))
+       endif
+       tmp_dx2=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i-1))
+       tmp_dx3=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i+1))
+       tmp_dx4=0.5_dp*(block(g)%deltax(i+1)+block(g)%deltax(i+2))
 
-	END SUBROUTINE non_uni_coeff
+       theta_1=tmp_dx2/tmp_dx1
+       theta_2=tmp_dx3/tmp_dx2
+       theta_3=tmp_dx4/tmp_dx3
+
+       f_1=theta_3
+       f_2=2.0_dp*theta_3+theta_3**2.0_dp
+       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
+       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
+       f_5=1.0_dp/(theta_1*theta_2)
+       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
+       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
+        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
+            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
+
+       s51=-1.0_dp/(theta_2**4.0_dp)
+       s52=f_4
+       s53=f_4
+       s54=s51
+       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
+       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
+       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+
+       s61=-1.0_dp
+       s62=f_8
+       s63=f_8
+       s64=-1.0_dp
+       s65=(f_5+f_8)
+       s66=(f_8-f_6)
+       s67=(f_7+f_8)
+
+       s71=-1.0_dp
+       s72=(1.0_dp+f_4)
+       s73=f_4
+       s74=(f_4-f_1)
+       s75=(f_4-f_2)
+       s76=(f_4-f_3)
+
+       s81=-1.0_dp/(theta_2**4.0_dp)
+       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
+       s83=f_8
+       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
+       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
+       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
+
+       s91=-s66*s51
+       s92=s56*s61
+       s93=-(s54*s66+s56*s62)
+       s94=(s56*s64+s66*s52)
+       s95=(s56*s63-s66*s53)
+       s96=(s56*s65-s66*s55)
+       s97=(s56*s67-s66*s57)
+
+       s101=-s85*s71
+       s102=-s85*s72
+       s103=s75*s81
+       s104=s75*s82
+       s105=(s75*s83-s85*s73)
+       s106=(s75*s84-s85*s74)
+       s107=(s75*s86-s85*s76)
+
+       block(g)%ca1_uv(i)=(s97*s101-s107*s91)
+       block(g)%ca1_uw(i)=block(g)%ca1_uv(i)
+       block(g)%ca2_uv(i)=(s97*s102+s107*s93)
+       block(g)%ca2_uw(i)=block(g)%ca2_uv(i)
+       block(g)%ca3_uv(i)=(s95*s107-s105*s97)
+       block(g)%ca3_uw(i)=block(g)%ca3_uv(i)
+       block(g)%ca4_uv(i)=(s94*s107+s104*s97)
+       block(g)%ca4_uw(i)=block(g)%ca4_uv(i)
+       block(g)%ca5_uv(i)=(s97*s103-s107*s92)
+       block(g)%ca5_uw(i)=block(g)%ca5_uv(i)
+       block(g)%ca6_uv(i)=(s97*s106-s107*s96)
+       block(g)%ca6_uw(i)=block(g)%ca6_uv(i)
+
+       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
+       ak_3=(1.0_dp+theta_1)
+       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
+       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
+       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+
+       block(g)%ck1_uv(i)=ak_3
+       block(g)%ck1_uw(i)=block(g)%ck1_uv(i)
+       block(g)%ck2_uv(i)=-ak_4
+       block(g)%ck2_uw(i)=block(g)%ck2_uv(i)
+       block(g)%ck3_uv(i)=(ak_1+ak_2)
+       block(g)%ck3_uw(i)=block(g)%ck3_uv(i)
+       block(g)%ck4_uv(i)=-ak_5
+       block(g)%ck4_uw(i)=block(g)%ck4_uv(i)
+       block(g)%ck5_uv(i)=ak_6
+       block(g)%ck5_uw(i)=block(g)%ck5_uv(i)
+       block(g)%ck6_uv(i)=ak_7
+       block(g)%ck6_uw(i)=block(g)%ck6_uv(i)
+       enddo
+        END DO
+
+        DO g=1,nblocks
+        nx_var=block(g)%nx
+        ny_var=block(g)%ny
+        nz_var=block(g)%nz
+       do j=2,ny_var
+       if(j==2)then
+       tmp_dy1=block(g)%deltay(j-1)
+       else
+       tmp_dy1=0.5_dp*(block(g)%deltay(j-1)+block(g)%deltay(j-2))
+       endif
+       tmp_dy2=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j-1))
+       tmp_dy3=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j+1))
+       tmp_dy4=0.5_dp*(block(g)%deltay(j+1)+block(g)%deltay(j+2))
+
+       theta_1=tmp_dy2/tmp_dy1
+       theta_2=tmp_dy3/tmp_dy2
+       theta_3=tmp_dy4/tmp_dy3
+
+       f_1=theta_3
+       f_2=2.0_dp*theta_3+theta_3**2.0_dp
+       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
+       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
+       f_5=1.0_dp/(theta_1*theta_2)
+       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
+       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
+        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
+            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
+
+       s51=-1.0_dp/(theta_2**4.0_dp)
+       s52=f_4
+       s53=f_4
+       s54=s51
+       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
+       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
+       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+
+       s61=-1.0_dp
+       s62=f_8
+       s63=f_8
+       s64=-1.0_dp
+       s65=(f_5+f_8)
+       s66=(f_8-f_6)
+       s67=(f_7+f_8)
+
+       s71=-1.0_dp
+       s72=(1.0_dp+f_4)
+       s73=f_4
+       s74=(f_4-f_1)
+       s75=(f_4-f_2)
+       s76=(f_4-f_3)
+
+       s81=-1.0_dp/(theta_2**4.0_dp)
+       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
+       s83=f_8
+       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
+       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
+       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
+
+       s91=-s66*s51
+       s92=s56*s61
+       s93=-(s54*s66+s56*s62)
+       s94=(s56*s64+s66*s52)
+       s95=(s56*s63-s66*s53)
+       s96=(s56*s65-s66*s55)
+       s97=(s56*s67-s66*s57)
+
+       s101=-s85*s71
+       s102=-s85*s72
+       s103=s75*s81
+       s104=s75*s82
+       s105=(s75*s83-s85*s73)
+       s106=(s75*s84-s85*s74)
+       s107=(s75*s86-s85*s76)
+
+       block(g)%ca1_vu(j)=(s97*s101-s107*s91)
+       block(g)%ca1_vw(j)=block(g)%ca1_vu(j)
+       block(g)%ca2_vu(j)=(s97*s102+s107*s93)
+       block(g)%ca2_vw(j)=block(g)%ca2_vu(j)
+       block(g)%ca3_vu(j)=(s95*s107-s105*s97)
+       block(g)%ca3_vw(j)=block(g)%ca3_vu(j)
+       block(g)%ca4_vu(j)=(s94*s107+s104*s97)
+       block(g)%ca4_vw(j)=block(g)%ca4_vu(j)
+       block(g)%ca5_vu(j)=(s97*s103-s107*s92)
+       block(g)%ca5_vw(j)=block(g)%ca5_vu(j)
+       block(g)%ca6_vu(j)=(s97*s106-s107*s96)
+       block(g)%ca6_vw(j)=block(g)%ca6_vu(j)
+
+       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
+       ak_3=(1.0_dp+theta_1)
+       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
+       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
+       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+
+       block(g)%ck1_vu(j)=ak_3
+       block(g)%ck1_vw(j)=block(g)%ck1_vu(j)
+       block(g)%ck2_vu(j)=-ak_4
+       block(g)%ck2_vw(j)=block(g)%ck2_vu(j)
+       block(g)%ck3_vu(j)=(ak_1+ak_2)
+       block(g)%ck3_vw(j)=block(g)%ck3_vu(j)
+       block(g)%ck4_vu(j)=-ak_5
+       block(g)%ck4_vw(j)=block(g)%ck4_vu(j)
+       block(g)%ck5_vu(j)=ak_6
+       block(g)%ck5_vw(j)=block(g)%ck5_vu(j)
+       block(g)%ck6_vu(j)=ak_7
+       block(g)%ck6_vw(j)=block(g)%ck6_vu(j)
+       enddo
+        ENDDO
+
+        DO g=1,nblocks
+        nx_var=block(g)%nx
+        ny_var=block(g)%ny
+        nz_var=block(g)%nz
+       do k=2,nz_var
+       if(k==2)then
+       tmp_dz1=block(g)%deltaz(k-1)
+       else
+       tmp_dz1=0.5_dp*(block(g)%deltaz(k-1)+block(g)%deltaz(k-2))
+       endif
+       tmp_dz2=0.5_dp*(block(g)%deltaz(k)+block(g)%deltaz(k-1))
+       tmp_dz3=0.5_dp*(block(g)%deltaz(k)+block(g)%deltaz(k+1))
+       tmp_dz4=0.5_dp*(block(g)%deltaz(k+1)+block(g)%deltaz(k+2))
+
+       theta_1=tmp_dz2/tmp_dz1
+       theta_2=tmp_dz3/tmp_dz2
+       theta_3=tmp_dz4/tmp_dz3
+
+       f_1=theta_3
+       f_2=2.0_dp*theta_3+theta_3**2.0_dp
+       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
+       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
+       f_5=1.0_dp/(theta_1*theta_2)
+       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
+       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
+        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
+            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
+
+       s51=-1.0_dp/(theta_2**4.0_dp)
+       s52=f_4
+       s53=f_4
+       s54=s51
+       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
+       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
+       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+
+       s61=-1.0_dp
+       s62=f_8
+       s63=f_8
+       s64=-1.0_dp
+       s65=(f_5+f_8)
+       s66=(f_8-f_6)
+       s67=(f_7+f_8)
+
+       s71=-1.0_dp
+       s72=(1.0_dp+f_4)
+       s73=f_4
+       s74=(f_4-f_1)
+       s75=(f_4-f_2)
+       s76=(f_4-f_3)
+
+       s81=-1.0_dp/(theta_2**4.0_dp)
+       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
+       s83=f_8
+       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
+       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
+       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
+
+       s91=-s66*s51
+       s92=s56*s61
+       s93=-(s54*s66+s56*s62)
+       s94=(s56*s64+s66*s52)
+       s95=(s56*s63-s66*s53)
+       s96=(s56*s65-s66*s55)
+       s97=(s56*s67-s66*s57)
+
+       s101=-s85*s71
+       s102=-s85*s72
+       s103=s75*s81
+       s104=s75*s82
+       s105=(s75*s83-s85*s73)
+       s106=(s75*s84-s85*s74)
+       s107=(s75*s86-s85*s76)
+
+       block(g)%ca1_wu(k)=(s97*s101-s107*s91)
+       block(g)%ca1_wv(k)=block(g)%ca1_wu(k)
+       block(g)%ca2_wu(k)=(s97*s102+s107*s93)
+       block(g)%ca2_wv(k)=block(g)%ca2_wu(k)
+       block(g)%ca3_wu(k)=(s95*s107-s105*s97)
+       block(g)%ca3_wv(k)=block(g)%ca3_wu(k)
+       block(g)%ca4_wu(k)=(s94*s107+s104*s97)
+       block(g)%ca4_wv(k)=block(g)%ca4_wu(k)
+       block(g)%ca5_wu(k)=(s97*s103-s107*s92)
+       block(g)%ca5_wv(k)=block(g)%ca5_wu(k)
+       block(g)%ca6_wu(k)=(s97*s106-s107*s96)
+       block(g)%ca6_wv(k)=block(g)%ca6_wu(k)
+
+       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
+       ak_3=(1.0_dp+theta_1)
+       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
+       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
+       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+
+       block(g)%ck1_wu(k)=ak_3
+       block(g)%ck1_wv(k)=block(g)%ck1_wu(k)
+       block(g)%ck2_wu(k)=-ak_4
+       block(g)%ck2_wv(k)=block(g)%ck2_wu(k)
+       block(g)%ck3_wu(k)=(ak_1+ak_2)
+       block(g)%ck3_wv(k)=block(g)%ck3_wu(k)
+       block(g)%ck4_wu(k)=-ak_5
+       block(g)%ck4_wv(k)=block(g)%ck4_wu(k)
+       block(g)%ck5_wu(k)=ak_6
+       block(g)%ck5_wv(k)=block(g)%ck5_wu(k)
+       block(g)%ck6_wu(k)=ak_7
+       block(g)%ck6_wv(k)=block(g)%ck6_wu(k)
+       enddo
+        END DO
+
+       write(*,*)'leaving non_uni_coeff'
+
+       END SUBROUTINE non_uni_coeff
 
       subroutine nsMomentum2order
 !c***********************************************************************
@@ -669,17 +669,17 @@ contains
 !c***********************************************************************
       INTEGER (dp) :: i, j, k, g, n ,nx_var,ny_var,nz_var, n1, nn, i11, j11, k11, &
            index_ip1, index_im1, index_jp1, index_jm1, index_kp1, index_km1
-	  REAL (dp) :: dpdx,dpdy,dpdz,u1a,u22,u3,u4,u5,u6,u7,u8,u9,u10,u11,u12,u13,u14, &
-	          u15,u16,v1a,v22,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16, &
-			  w1a,w22,w3,w4,w5,w6,w7,w8,w9,w10,w11,w12,w13,w14,w15,w16,dx2xr, &
-			  dx2xl,dy2ye,dy2yw, dxr, dx, dxl, dye, dy, dyw, dzt, dz, dzb, &
-			  dz2zt,dz2zb,ddx,ddxr,ddy,ddye,ddz,ddzr,dwudz, &
-			  wu_n,wu_s,w_in_um,vu_e,vu_w,v_in_um,duutdx,dvutdy, &
-			  dwutdz,duudx,dvudy,d2udx2,d2udy2,d2udz2, &
-			  uv_e,uv_w,u_in_vm,wv_n,wv_s,w_in_vm,duvtdx,dvvtdy,dwvtdz, &
-			  duvdx,dvvdy,dwvdz,d2vdx2,d2vdy2,d2vdz2,uw_e,uw_w, &
-			  u_in_wm,vw_n,vw_s,v_in_wm,duwtdx,dvwtdy,dwwtdz, &
-			  duwdx,dvwdy,dwwdz,d2wdx2,d2wdy2,d2wdz2,xtt2,residu,ytt2,residv,&
+         REAL (dp) :: dpdx,dpdy,dpdz,u1a,u22,u3,u4,u5,u6,u7,u8,u9,u10,u11,u12,u13,u14, &
+                 u15,u16,v1a,v22,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16, &
+                       w1a,w22,w3,w4,w5,w6,w7,w8,w9,w10,w11,w12,w13,w14,w15,w16,dx2xr, &
+                       dx2xl,dy2ye,dy2yw, dxr, dx, dxl, dye, dy, dyw, dzt, dz, dzb, &
+                       dz2zt,dz2zb,ddx,ddxr,ddy,ddye,ddz,ddzr,dwudz, &
+                       wu_n,wu_s,w_in_um,vu_e,vu_w,v_in_um,duutdx,dvutdy, &
+                       dwutdz,duudx,dvudy,d2udx2,d2udy2,d2udz2, &
+                       uv_e,uv_w,u_in_vm,wv_n,wv_s,w_in_vm,duvtdx,dvvtdy,dwvtdz, &
+                       duvdx,dvvdy,dwvdz,d2vdx2,d2vdy2,d2vdz2,uw_e,uw_w, &
+                       u_in_wm,vw_n,vw_s,v_in_wm,duwtdx,dvwtdy,dwwtdz, &
+                       duwdx,dvwdy,dwwdz,d2wdx2,d2wdy2,d2wdz2,xtt2,residu,ytt2,residv,&
                           ztt2,residw, temp_u1dotn, temp_u2dotn, temp_v1dotn, temp_v2dotn, &
                           temp_w1dotn, temp_w2dotn, temp_pdotn
      al = 1.
@@ -860,10 +860,10 @@ contains
                    IF (temp_v1dotn<0) THEN
                       block(g)%v(i-1,j-1,k) = block(g)%v1_ghost(index_im1)
                    ENDIF
-		             IF (temp_w2dotn<0) THEN
+                           IF (temp_w2dotn<0) THEN
                       block(g)%w(i-1,j,k) = block(g)%w2_ghost(index_im1)
                    ENDIF
-		             IF (temp_w1dotn<0) THEN
+                           IF (temp_w1dotn<0) THEN
                       block(g)%w(i-1,j,k-1) = block(g)%w1_ghost(index_im1)
                    ENDIF
                    IF (temp_pdotn<0) THEN
@@ -877,7 +877,7 @@ contains
                    temp_u1dotn = 0.
                    temp_v2dotn = 0.
                    temp_v1dotn = 0.
-		             temp_w2dotn = 0.
+                           temp_w2dotn = 0.
                    temp_w1dotn = 0.
                    temp_pdotn  = 0.
                    temp_u2dotn = (block(g)%x1(i+1) - &
@@ -931,10 +931,10 @@ contains
                    IF (temp_v2dotn<0) THEN
                       block(g)%v(i,j+1,k) = block(g)%v2_ghost(index_jp1)
                    ENDIF
-		             IF (temp_w2dotn<0) THEN
+                           IF (temp_w2dotn<0) THEN
                       block(g)%w(i,j+1,k) = block(g)%w2_ghost(index_jp1)
                    ENDIF
-		             IF (temp_w1dotn<0) THEN
+                           IF (temp_w1dotn<0) THEN
                       block(g)%w(i,j+1,k-1) = block(g)%w1_ghost(index_jp1)
                    ENDIF
                    IF (temp_pdotn<0) THEN
@@ -942,13 +942,13 @@ contains
                    ENDIF
                 ENDIF
 
-		          IF (block(g)%cell2(i, j-1, k)==2) THEN
+                        IF (block(g)%cell2(i, j-1, k)==2) THEN
                    index_jm1 = nn
                    temp_u2dotn = 0.
                    temp_u1dotn = 0.
                    temp_v2dotn = 0.
                    temp_v1dotn = 0.
-		             temp_w2dotn = 0.
+                           temp_w2dotn = 0.
                    temp_w1dotn = 0.
                    temp_pdotn  = 0.
                    temp_u2dotn = (block(g)%x1(i+1) - &
@@ -1019,7 +1019,7 @@ contains
                    temp_u1dotn = 0.
                    temp_v2dotn = 0.
                    temp_v1dotn = 0.
-		             temp_w2dotn = 0.
+                           temp_w2dotn = 0.
                    temp_w1dotn = 0.
                    temp_pdotn  = 0.
                    temp_u2dotn = (block(g)%x1(i+1) - &
@@ -1157,15 +1157,15 @@ contains
 
              ENDDO
       ENDIF
-	   dxr=block(g)%deltax(i+1)
-	   dx=block(g)%deltax(i)
-	   dxl=block(g)%deltax(i-1)
-	   dye=block(g)%deltay(j+1)
-	   dy=block(g)%deltay(j)
-	   dyw=block(g)%deltay(j-1)
-	   dzt=block(g)%deltaz(k+1)
-	   dz=block(g)%deltaz(k)
-	   dzb=block(g)%deltaz(k-1)
+          dxr=block(g)%deltax(i+1)
+          dx=block(g)%deltax(i)
+          dxl=block(g)%deltax(i-1)
+          dye=block(g)%deltay(j+1)
+          dy=block(g)%deltay(j)
+          dyw=block(g)%deltay(j-1)
+          dzt=block(g)%deltaz(k+1)
+          dz=block(g)%deltaz(k)
+          dzb=block(g)%deltaz(k-1)
 !cccccccccccccccccccccccccc  diff-u     ccccccccccccccccccccccccccccccccc
 !c     duu / dx
        u1a = block(g)%u(i-1,j,k) + block(g)%u(i,j,k)
@@ -1249,20 +1249,20 @@ contains
        dpdy = (block(g)%p(i,j,k) - block(g)%p(i,j+1,k))/(0.5_dp*(dye+dy))
        dpdz = (block(g)%p(i,j,k) - block(g)%p(i,j,k+1))/(0.5_dp*(dzt+dz))
 
-    	 dx2xr = dx + dxr
+            dx2xr = dx + dxr
        dx2xl = dx + dxl
-	    dy2ye = dy + dye
-	    dy2yw = dy + dyw
-	    dz2zt = dz + dzt
-	    dz2zb = dz + dzb
+           dy2ye = dy + dye
+           dy2yw = dy + dyw
+           dz2zt = dz + dzt
+           dz2zb = dz + dzb
 !c*********************** U - Momentum **********************************
-	    vu_e=block(g)%v(i+1,j,k)+(dxr/(dx2xr))*(block(g)%v(i,j,k)-block(g)%v(i+1,j,k))
-	    vu_w=block(g)%v(i+1,j-1,k)+(dxr/(dx2xr))*(block(g)%v(i,j-1,k)-block(g)%v(i+1,j-1,k))
-	    v_in_um=0.5_dp*(vu_e+vu_w)
+           vu_e=block(g)%v(i+1,j,k)+(dxr/(dx2xr))*(block(g)%v(i,j,k)-block(g)%v(i+1,j,k))
+           vu_w=block(g)%v(i+1,j-1,k)+(dxr/(dx2xr))*(block(g)%v(i,j-1,k)-block(g)%v(i+1,j-1,k))
+           v_in_um=0.5_dp*(vu_e+vu_w)
 
-	    wu_n=block(g)%w(i+1,j,k)+(dxr/(dx2xr))*(block(g)%w(i,j,k)-block(g)%w(i+1,j,k))
-	    wu_s=block(g)%w(i+1,j,k-1)+(dxr/(dx2xr))*(block(g)%w(i,j,k-1)-block(g)%w(i+1,j,k-1))
-	    w_in_um=0.5_dp*(wu_n+wu_s)
+           wu_n=block(g)%w(i+1,j,k)+(dxr/(dx2xr))*(block(g)%w(i,j,k)-block(g)%w(i+1,j,k))
+           wu_s=block(g)%w(i+1,j,k-1)+(dxr/(dx2xr))*(block(g)%w(i,j,k-1)-block(g)%w(i+1,j,k-1))
+           w_in_um=0.5_dp*(wu_n+wu_s)
 
 !cccccccccccccc---Third Order Upwinding ----ccccccccccccccccccccccccccccc
        if(i>2.and.i<nx_var.and.j>2.and.j<ny_var+1.and. &
@@ -1275,7 +1275,7 @@ contains
       block(g)%cell2(i,j,k-2)/=2) THEN
 
 
-	    ddy=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j-1))
+           ddy=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j-1))
        ddye=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j+1))
        ddz=0.5_dp*(block(g)%deltaz(k)+block(g)%deltaz(k-1))
        ddzr=0.5_dp*(block(g)%deltaz(k)+block(g)%deltaz(k+1))
@@ -1308,11 +1308,11 @@ contains
       block(g)%ck5_wu(k)* &
       block(g)%u(i,j,k-2))/(2.0_dp*block(g)%ck6_wu(k)*ddz)
 
-     	duudx=duutdx
+            duudx=duutdx
        dvudy=dvutdy
        dwudz=dwutdz
 
-	else
+       else
  !cccccccccccccc---First Order Upwinding ----ccccccccccccccccccccccccccccc
    duudx = -0.25_dp*( u1a*u1a + alpha*dabs(u1a)*u22-u3*u3-alpha*dabs(u3)*u4)/block(g)%deltax(i)
 
@@ -1323,12 +1323,12 @@ contains
        endif
 
 !ccccccccccccccccccccccccc  grad of u part cccccccccccccccccccccccccccccc
-	d2udx2=(2.0_dp/dx2xr)*((-u4/dxr)+(u22/dx))
+       d2udx2=(2.0_dp/dx2xr)*((-u4/dxr)+(u22/dx))
 
        d2udy2=(2.0_dp/(0.5_dp*(dy2ye+dy2yw)))*((-u8/(0.5_dp*dy2ye))+ &
       (u6/(0.5_dp*dy2yw)))
 
-	d2udz2=(2.0_dp/(0.5_dp*(dz2zt+dz2zb)))*((-u12/(0.5_dp*dz2zt))+ &
+       d2udz2=(2.0_dp/(0.5_dp*(dz2zt+dz2zb)))*((-u12/(0.5_dp*dz2zt))+ &
       (u10/(0.5_dp*dz2zb)))
 
        xtt2=(d2udx2+d2udy2+d2udz2)/re
@@ -1338,13 +1338,13 @@ contains
 
        block(g)%resi_u(i,j,k)=residu
 !c*********************** V - Momentum *********************************
-	uv_e=block(g)%u(i,j+1,k)+(dye/(dy2ye))*(block(g)%u(i,j,k)-block(g)%u(i,j+1,k))
-	uv_w=block(g)%u(i-1,j+1,k)+(dye/(dy2ye))*(block(g)%u(i-1,j,k)-block(g)%u(i-1,j+1,k))
-	u_in_vm=0.5_dp*(uv_e+uv_w)
+       uv_e=block(g)%u(i,j+1,k)+(dye/(dy2ye))*(block(g)%u(i,j,k)-block(g)%u(i,j+1,k))
+       uv_w=block(g)%u(i-1,j+1,k)+(dye/(dy2ye))*(block(g)%u(i-1,j,k)-block(g)%u(i-1,j+1,k))
+       u_in_vm=0.5_dp*(uv_e+uv_w)
 
-	wv_n=block(g)%w(i,j+1,k)+(dye/(dy2ye))*(block(g)%w(i,j,k)-block(g)%w(i,j+1,k))
-	wv_s=block(g)%w(i,j+1,k-1)+(dye/(dy2ye))*(block(g)%w(i,j,k-1)-block(g)%w(i,j+1,k-1))
-	w_in_vm=0.5_dp*(wv_n+wv_s)
+       wv_n=block(g)%w(i,j+1,k)+(dye/(dy2ye))*(block(g)%w(i,j,k)-block(g)%w(i,j+1,k))
+       wv_s=block(g)%w(i,j+1,k-1)+(dye/(dy2ye))*(block(g)%w(i,j,k-1)-block(g)%w(i,j+1,k-1))
+       w_in_vm=0.5_dp*(wv_n+wv_s)
 
 !cccccccccccccc---Third Order Upwinding ----cccccccccccccccccccccccccccc
      if(i>2.and.i<nx_var+1.and.j>2.and.j<ny_var.and. &
@@ -1355,7 +1355,7 @@ contains
       block(g)%cell2(i,j+2,k)/=2.and.block(g)%cell2(i,j,k+2)/=2.and. &
       block(g)%cell2(i-2,j,k)/=2.and.block(g)%cell2(i,j-2,k)/=2.and. &
       block(g)%cell2(i,j,k-2)/=2) THEN
-	ddx=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i-1))
+       ddx=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i-1))
        ddxr=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i+1))
        ddz=0.5_dp*(block(g)%deltaz(k)+block(g)%deltaz(k-1))
        ddzr=0.5_dp*(block(g)%deltaz(k)+block(g)%deltaz(k+1))
@@ -1391,7 +1391,7 @@ contains
 
        else
 !cccccccccccccc---First Order Upwinding ----ccccccccccccccccccccccccccccc
-	  duvdx = -0.25_dp*(u13*v3 + alpha*dabs(u13)*v4- u14*v5 - alpha*dabs(u14)*v6)/block(g)%deltax(i)
+      duvdx = -0.25_dp*(u13*v3 + alpha*dabs(u13)*v4- u14*v5 - alpha*dabs(u14)*v6)/block(g)%deltax(i)
 
       dvvdy = -0.25_dp*(v7*v7 + alpha*dabs(v7)*v8 -v9*v9 - alpha*dabs(v9)*v10)/block(g)%deltay(j)
 
@@ -1400,13 +1400,13 @@ contains
        endif
 
 !ccccccccccccccccccccccccc  grad of v part cccccccccccccccccccccccccccccc
-	d2vdx2=(2.0_dp/(0.5_dp*(dx2xr+dx2xl)))*((-v6/(0.5_dp*dx2xr))+ &
-	(v4/(0.5_dp*dx2xl)))
+       d2vdx2=(2.0_dp/(0.5_dp*(dx2xr+dx2xl)))*((-v6/(0.5_dp*dx2xr))+ &
+       (v4/(0.5_dp*dx2xl)))
 
        d2vdy2=(2.0_dp/dy2ye)*((-v10/dye)+(v8/dy))
 
-	d2vdz2=(2.0_dp/(0.5_dp*(dz2zt+dz2zb)))*((-v14/(0.5_dp*dz2zt))+ &
-	(v12/(0.5_dp*dz2zb)))
+       d2vdz2=(2.0_dp/(0.5_dp*(dz2zt+dz2zb)))*((-v14/(0.5_dp*dz2zt))+ &
+       (v12/(0.5_dp*dz2zb)))
 
        ytt2=(d2vdx2+d2vdy2+d2vdz2)/re
 
@@ -1416,13 +1416,13 @@ contains
 
        block(g)%resi_v(i,j,k)=residv
 !c*********************** W - Momentum **********************************
-	uw_e=block(g)%u(i,j,k+1)+(dzt/(dz2zt))*(block(g)%u(i,j,k)-block(g)%u(i,j,k+1))
-	uw_w=block(g)%u(i-1,j,k+1)+(dzt/(dz2zt))*(block(g)%u(i-1,j,k)-block(g)%u(i-1,j,k+1))
-	u_in_wm=0.5_dp*(uw_e+uw_w)
+       uw_e=block(g)%u(i,j,k+1)+(dzt/(dz2zt))*(block(g)%u(i,j,k)-block(g)%u(i,j,k+1))
+       uw_w=block(g)%u(i-1,j,k+1)+(dzt/(dz2zt))*(block(g)%u(i-1,j,k)-block(g)%u(i-1,j,k+1))
+       u_in_wm=0.5_dp*(uw_e+uw_w)
 
-	vw_n=block(g)%v(i,j,k+1)+(dzt/(dz2zt))*(block(g)%v(i,j,k)-block(g)%v(i,j,k+1))
-	vw_s=block(g)%v(i,j-1,k+1)+(dzt/(dz2zt))*(block(g)%v(i,j-1,k)-block(g)%v(i,j-1,k+1))
-	v_in_wm=0.5_dp*(vw_n+vw_s)
+       vw_n=block(g)%v(i,j,k+1)+(dzt/(dz2zt))*(block(g)%v(i,j,k)-block(g)%v(i,j,k+1))
+       vw_s=block(g)%v(i,j-1,k+1)+(dzt/(dz2zt))*(block(g)%v(i,j-1,k)-block(g)%v(i,j-1,k+1))
+       v_in_wm=0.5_dp*(vw_n+vw_s)
 
 !cccccccccccccc---Third Order Upwinding ----ccccccccccccccccccccccccccccc
      if(i>2.and.i<nx_var+1.and.j>2.and.j<ny_var+1.and. &
@@ -1434,7 +1434,7 @@ contains
       block(g)%cell2(i-2,j,k)/=2.and.block(g)%cell2(i,j-2,k)/=2.and. &
       block(g)%cell2(i,j,k-2)/=2) THEN
 
-	ddx=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i-1))
+       ddx=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i-1))
        ddxr=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i+1))
        ddy=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j-1))
        ddye=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j+1))
@@ -1469,11 +1469,11 @@ contains
       block(g)%ck5_ww(k)* &
       block(g)%w(i,j,k-2))/(2.0_dp*block(g)%ck6_ww(k)*block(g)%deltaz(k))
 
-     	duwdx=duwtdx
+            duwdx=duwtdx
        dvwdy=dvwtdy
        dwwdz=dwwtdz
 
-	else
+       else
 !cccccccccccccc---First Order Upwinding ----cccccccccccccccccccccccccccc
 
    duwdx=-0.5_dp*(u15*w5 + alpha*dabs(u15)*w6 -  u16*w7 - alpha*dabs(u16)*w8)/block(g)%deltax(i)
@@ -1486,13 +1486,13 @@ contains
 
 !ccccccccccccccccccccccccc  grad of w part cccccccccccccccccccccccccccccc
 
-	d2wdx2=(2.0_dp/(0.5_dp*(dx2xr+dx2xl)))*((-W8/(0.5_dp*dx2xr))+ &
+       d2wdx2=(2.0_dp/(0.5_dp*(dx2xr+dx2xl)))*((-W8/(0.5_dp*dx2xr))+ &
       (W6/(0.5_dp*dx2xl)))
 
-	d2wdy2=(2.0_dp/(0.5_dp*(dy2ye+dy2yw)))*((-W12/(0.5_dp*dy2ye))+ &
+       d2wdy2=(2.0_dp/(0.5_dp*(dy2ye+dy2yw)))*((-W12/(0.5_dp*dy2ye))+ &
       (W10/(0.5_dp*dy2yw)))
 
-	d2wdz2=(2.0_dp/dz2zt)*((-w16/dzt)+(w14/dz))
+       d2wdz2=(2.0_dp/dz2zt)*((-w16/dzt)+(w14/dz))
 
        ztt2=(d2wdx2+d2wdy2+d2wdz2)/re
 
@@ -1551,11 +1551,11 @@ IF (block(g)%cell2(i, j, k-1)==2) THEN
    block(g)%w(i,j,k-2)   = block(g)%w1t_ghost(index_km1)
    block(g)%p(i,j,k-1)   = block(g)%pt_ghost(index_km1)
 ENDIF
-	ENDDO
+       ENDDO
 !c***********************************************************************
      !$acc end parallel
         !$acc wait
 
-	ENDDO
+       ENDDO
       end subroutine nsMomentum2order
 end module biocfd_navier_stokes


### PR DESCRIPTION
Follow up to #52. I think that the pedantic flag could be added now (as an error flag).

There should be no none-whitespace changes.

Also, adds the `-pedantic-errors` flag to our `gfortran` build CI.