### PR TITLE
Remove use of rk throughout (replace with dp)

### DIFF
--- a/src/CoefficientMatrix.f90
+++ b/src/CoefficientMatrix.f90
@@ -9,7 +9,7 @@ module biocfd_coefficient_matrix
 
   contains
 SUBROUTINE coefficientMatrix
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
+
         INTEGER (int64) :: i, j, f,nx_var,ny_var,nz_var
         REAL (dp)    ::  rx1, rx2, rxsum, ry1, ry2, rysum, rz1, rz2, rzsum
 
@@ -21,50 +21,50 @@ SUBROUTINE coefficientMatrix
             ry1   = block(f)%yp(j)   - block(f)%yp(j-1)
             ry2   = block(f)%yp(j+1) - block(f)%yp(j)
             rysum = ry1 + ry2
-            block(f)%Acy(j-1, 1) =   2._rk/(ry1*rysum)
-            block(f)%Acy(j-1, 2) =  -2._rk/(ry1*ry2)
-            block(f)%Acy(j-1, 3) =   2._rk/(ry2*rysum)
+            block(f)%Acy(j-1, 1) =   2._dp/(ry1*rysum)
+            block(f)%Acy(j-1, 2) =  -2._dp/(ry1*ry2)
+            block(f)%Acy(j-1, 3) =   2._dp/(ry2*rysum)
          END DO
 
          DO i = 2, nx_var+1
             rx1   = block(f)%xp(i)   - block(f)%xp(i-1)
             rx2   = block(f)%xp(i+1) - block(f)%xp(i)
             rxsum = rx1 + rx2
-            block(f)%Acx(i-1, 1) =   2._rk/(rx1*rxsum)
-            block(f)%Acx(i-1, 2) =  -2._rk/(rx1*rx2)
-            block(f)%Acx(i-1, 3) =   2._rk/(rx2*rxsum)
+            block(f)%Acx(i-1, 1) =   2._dp/(rx1*rxsum)
+            block(f)%Acx(i-1, 2) =  -2._dp/(rx1*rx2)
+            block(f)%Acx(i-1, 3) =   2._dp/(rx2*rxsum)
          END DO
 
          DO i = 2, nz_var+1
             rz1   = block(f)%zp(i)   - block(f)%zp(i-1)
             rz2   = block(f)%zp(i+1) - block(f)%zp(i)
             rzsum = rz1 + rz2
-            block(f)%Acz(i-1, 1) =   2._rk/(rz1*rzsum)
-            block(f)%Acz(i-1, 2) =  -2._rk/(rz1*rz2)
-            block(f)%Acz(i-1, 3) =   2._rk/(rz2*rzsum)
+            block(f)%Acz(i-1, 1) =   2._dp/(rz1*rzsum)
+            block(f)%Acz(i-1, 2) =  -2._dp/(rz1*rz2)
+            block(f)%Acz(i-1, 3) =   2._dp/(rz2*rzsum)
          END DO
 
 
          if (f ==1)then
          !inlet, i = 1
          block(f)%Acx(1, 2)   =  block(f)%Acx(1, 2)  - block(f)%Acx(1, 1)
-         block(f)%Acx(1, 1)   =  0._rk
+         block(f)%Acx(1, 1)   =  0._dp
          !outlet, i = nx_var
          block(f)%Acx(nx_var, 2)  =  block(f)%Acx(nx_var, 2) - block(f)%Acx(nx_var, 3)
-         block(f)%Acx(nx_var, 3)  =  0._rk
+         block(f)%Acx(nx_var, 3)  =  0._dp
 
          block(f)%Acy(1, 2)   =  block(f)%Acy(1, 2)  + block(f)%Acy(1, 1)
-         block(f)%Acy(1, 1)   =  0._rk
+         block(f)%Acy(1, 1)   =  0._dp
          !top, i = ny_var
          block(f)%Acy(ny_var, 2)  =  block(f)%Acy(ny_var, 2) +  block(f)%Acy(ny_var, 3)
-         block(f)%Acy(ny_var, 3)  =  0._rk
+         block(f)%Acy(ny_var, 3)  =  0._dp
 
         	 !front, k = 1
          block(f)%Acz(1, 2)   =  block(f)%Acz(1, 2) + block(f)%Acz(1, 1)
-         block(f)%Acz(1, 1)   =  0._rk
+         block(f)%Acz(1, 1)   =  0._dp
          !back, k = nz_var
          block(f)%Acz(nz_var, 2)  =  block(f)%Acz(nz_var, 2) + block(f)%Acz(nz_var, 3)
-         block(f)%Acz(nz_var, 3)  =  0._rk
+         block(f)%Acz(nz_var, 3)  =  0._dp
        end if
         END DO
 

--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -11,14 +11,14 @@ module biocfd_forcing
 
   contains
 SUBROUTINE pressureForcing1
-      INTEGER, PARAMETER :: rk = selected_real_kind(8)
+
       INTEGER :: n, k, j, i, il, jl, kl, i_x1, i_y1, i_z1, g
       REAL (dp) :: n1, pos1_x, pos1_y, pos1_z, pt1, &
                          aval, bval, cval, p_pos1, sur2nodeDis, dpdn, p_x1, p_x2, &
                          p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, &
                          p_z1_x1, p_z2_x1, p_z1_x2, p_z2_x2, h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e
 
-      dpdn = 0._rk
+      dpdn = 0._dp
         DO g=blk_start,nblocks
 
 
@@ -65,7 +65,7 @@ SUBROUTINE pressureForcing1
 
          sur2nodeDis = block(g)%pNormDis(n)
 
-         pt1 = 1.5_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
+         pt1 = 1.5_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -169,7 +169,7 @@ SUBROUTINE pressureForcing1
 END SUBROUTINE pressureForcing1
 
 SUBROUTINE velocityForcing1
-      INTEGER, PARAMETER :: rk = selected_real_kind(8)
+
       INTEGER :: n, k, j, i, il, jl, kl, i_x1, i_y1, i_z1, g
       REAL (dp) :: n1, pos1_x, pos1_y, pos1_z, pt1,  &
                          aval, bval, cval, sur2nodeDis, h1, h2, &
@@ -214,7 +214,7 @@ SUBROUTINE velocityForcing1
 !***********************U(i,j,k)****************************************
          sur2nodeDis = block(g)%u2NormDis(n)
 
-         pt1 = 1.5_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
+         pt1 = 1.5_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -322,7 +322,7 @@ SUBROUTINE velocityForcing1
          ENDIF
          sur2nodeDis = block(g)%u1NormDis(n)
 
-         pt1 = 1.5_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
+         pt1 = 1.5_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -436,7 +436,7 @@ SUBROUTINE velocityForcing1
 
          sur2nodeDis = block(g)%v2NormDis(n)
 
-         pt1 = 1.5_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 &
+         pt1 = 1.5_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 &
                + block(g)%deltaz(k)**2) + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -549,7 +549,7 @@ SUBROUTINE velocityForcing1
          ENDIF
          sur2nodeDis = block(g)%v1NormDis(n)
 
-         pt1 = 1.5_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
+         pt1 = 1.5_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -660,7 +660,7 @@ SUBROUTINE velocityForcing1
          ENDIF
          sur2nodeDis = block(g)%w2NormDis(n)
 
-         pt1 = 1.5_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
+         pt1 = 1.5_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -759,7 +759,7 @@ SUBROUTINE velocityForcing1
          avaL = dwdn_e/n1 - (w_pos1 - wsurf)/n1**2
          block(g)%wt(i,j,k) = aval*sur2nodeDis**2 + bval*sur2nodeDis + cval
 !**************************W(i,j,k-1)*************************************
-         wsurf = 0._rk
+         wsurf = 0._dp
          IF (block(g)%ibSurfID(block(g)%nelw1(n))==50) THEN
            wsurf = 0.
          ELSEIF (block(g)%ibSurfID(block(g)%nelw1(n))==51) THEN
@@ -771,7 +771,7 @@ SUBROUTINE velocityForcing1
          ENDIF
          sur2nodeDis = block(g)%w1NormDis(n)
 
-         pt1 = 1.5_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
+         pt1 = 1.5_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -876,7 +876,7 @@ SUBROUTINE velocityForcing1
 END SUBROUTINE velocityForcing1
 
 SUBROUTINE pressureForcingGhost
-      INTEGER, PARAMETER :: rk = selected_real_kind(8)
+
       INTEGER :: g,n, k, j, i, il, jl, kl, i_x1, i_y1, i_z1
       REAL (dp) :: n1, pos1_x, pos1_y, pos1_z, pt1, &
                          aval, bval, cval, p_pos1, sur2nodeDis, dpdn, &
@@ -885,7 +885,7 @@ SUBROUTINE pressureForcingGhost
                          h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e
 
         DO g=blk_start, nblocks
-      dpdn = 0._rk
+      dpdn = 0._dp
  !$acc parallel loop gang vector                                                                    &
  !$acc private (diagCell, n1, pos1_x, pos1_y, pos1_z, pt1, aval, bval, cval, p_pos1, sur2nodeDis, dpdn,                   &
  !$acc           p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1,                &
@@ -937,7 +937,7 @@ SUBROUTINE pressureForcingGhost
 
          sur2nodeDis = -block(g)%pNormDis(block(g)%index_ts(n))
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 &
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 &
                              + block(g)%deltay(j)**2 &
                              + block(g)%deltaz(k)**2) &
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
@@ -1041,7 +1041,7 @@ SUBROUTINE pressureForcingGhost
 END SUBROUTINE pressureForcingGhost
 
 SUBROUTINE velocityForcingGhost
-      INTEGER, PARAMETER :: rk = selected_real_kind(8)
+
       INTEGER :: g,n, k, j, i, il, jl, kl, i_x1, i_y1, i_z1
       REAL (dp) :: n1, pos1_x, pos1_y, pos1_z, pt1,  &
                          aval, bval, cval, sur2nodeDis, h1, h2, &
@@ -1084,7 +1084,7 @@ SUBROUTINE velocityForcingGhost
 
          sur2nodeDis = -block(g)%u2NormDis(block(g)%index_ts(n))
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 &
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 &
                + block(g)%deltay(j)**2 &
                + block(g)%deltaz(k)**2) &
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
@@ -1194,7 +1194,7 @@ SUBROUTINE velocityForcingGhost
 
          sur2nodeDis = -block(g)%u1NormDis(block(g)%index_ts(n))
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -1311,7 +1311,7 @@ SUBROUTINE velocityForcingGhost
 
          sur2nodeDis = -block(g)%v2NormDis(block(g)%index_ts(n))
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -1431,7 +1431,7 @@ SUBROUTINE velocityForcingGhost
 
          sur2nodeDis = -block(g)%v1NormDis(block(g)%index_ts(n))
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 &
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 &
                + block(g)%deltaz(k)**2) + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -1530,7 +1530,7 @@ SUBROUTINE velocityForcingGhost
          block(g)%v1_ghost(n) = aval*sur2nodeDis**2 + bval*sur2nodeDis + cval
          block(g)%v1t_ghost(n) = block(g)%v(i,j-1,k)
 !**************************W(i,j,k)*************************************
-         wsurf = 0._rk
+         wsurf = 0._dp
          IF (block(g)%ibSurfID(block(g)%nelw2(block(g)%index_ts(n)))==50) THEN
            wsurf = 0.
          ELSEIF (block(g)%ibSurfID(block(g)%nelw2(block(g)%index_ts(n)))==51) THEN
@@ -1546,7 +1546,7 @@ SUBROUTINE velocityForcingGhost
 
          sur2nodeDis = -block(g)%w2NormDis(block(g)%index_ts(n))
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -1646,7 +1646,7 @@ SUBROUTINE velocityForcingGhost
          !ENDIF
          block(g)%w2t_ghost(n) = block(g)%w(i,j,k)
 !**************************W(i,j,k-1)*************************************
-         wsurf = 0._rk
+         wsurf = 0._dp
          IF (block(g)%ibSurfID(block(g)%nelw1(block(g)%index_ts(n)))==50) THEN
            wsurf = 0.
          ELSEIF (block(g)%ibSurfID(block(g)%nelw1(block(g)%index_ts(n)))==51) THEN
@@ -1662,7 +1662,7 @@ SUBROUTINE velocityForcingGhost
 
          sur2nodeDis = -block(g)%w1NormDis(block(g)%index_ts(n))
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -1767,7 +1767,7 @@ END SUBROUTINE velocityForcingGhost
 !***********************************************************************
 
 SUBROUTINE pressureForcingField
-      INTEGER, PARAMETER :: rk = selected_real_kind(8)
+
       INTEGER :: g,n, k, j, i, il, jl, kl, i_x1, i_y1, i_z1
       REAL (dp) :: n1, pos1_x, pos1_y, pos1_z, pt1, &
                          aval, bval, cval, p_pos1, sur2nodeDis, dpdn, &
@@ -1776,7 +1776,7 @@ SUBROUTINE pressureForcingField
                          h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e
 
        DO g=blk_start,nblocks
-      dpdn = 0._rk
+      dpdn = 0._dp
  !$acc parallel loop gang vector                                                                                          &
  !$acc private (diagCell, n1, pos1_x, pos1_y, pos1_z, pt1, aval, bval, cval, p_pos1, sur2nodeDis, dpdn,                   &
  !$acc           p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1,                &
@@ -1819,7 +1819,7 @@ SUBROUTINE pressureForcingField
 
          sur2nodeDis = block(g)%pNormDis(n)
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -1922,7 +1922,7 @@ SUBROUTINE pressureForcingField
 END SUBROUTINE pressureForcingField
 
 SUBROUTINE velocityForcingField
-      INTEGER, PARAMETER :: rk = selected_real_kind(8)
+
       INTEGER :: g,n, k, j, i, il, jl, kl, i_x1, i_y1, i_z1
       REAL (dp) :: n1, pos1_x, pos1_y, pos1_z, pt1,  &
                          aval, bval, cval, sur2nodeDis, h1, h2, &
@@ -1967,7 +1967,7 @@ SUBROUTINE velocityForcingField
 
          sur2nodeDis = block(g)%u2NormDis(n)
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -2074,7 +2074,7 @@ SUBROUTINE velocityForcingField
 
          sur2nodeDis = block(g)%u1NormDis(n)
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 &
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 &
                + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2) &
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
@@ -2188,7 +2188,7 @@ SUBROUTINE velocityForcingField
 
          sur2nodeDis = block(g)%v2NormDis(n)
 
-         pt1 = 1.21_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
+         pt1 = 1.21_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -2305,7 +2305,7 @@ SUBROUTINE velocityForcingField
          !vsurf =  -block(g)%thetaDot*(block(g)%xcent(block(g)%nelv1(n)) - block(g)%piv_x) + ydot
          sur2nodeDis = block(g)%v1NormDis(n)
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
               + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -2414,7 +2414,7 @@ SUBROUTINE velocityForcingField
          ENDIF
 
          sur2nodeDis = block(g)%w2NormDis(n)
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node
@@ -2511,7 +2511,7 @@ SUBROUTINE velocityForcingField
          avaL = dwdn_e/n1 - (w_pos1 - wsurf)/n1**2
          block(g)%w(i,j,k) = aval*sur2nodeDis**2 + bval*sur2nodeDis + cval
 !**************************W(i,j,k-1)*************************************
-         wsurf = 0._rk
+         wsurf = 0._dp
          IF (block(g)%ibSurfID(block(g)%nelw1(n))==50) THEN
            wsurf = 0.
          ELSEIF (block(g)%ibSurfID(block(g)%nelw1(n))==51) THEN
@@ -2524,7 +2524,7 @@ SUBROUTINE velocityForcingField
 
          sur2nodeDis = block(g)%w1NormDis(n)
 
-         pt1 = 1.51_rk*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
+         pt1 = 1.51_dp*dsqrt(block(g)%deltax(i)**2 + block(g)%deltay(j)**2 + block(g)%deltaz(k)**2)&
                + (dabs(sur2nodeDis)-sur2nodeDis)*0.5_dp
 
          !coordinates of three points from interceptd cell pressure node

--- a/src/InitialConditions.f90
+++ b/src/InitialConditions.f90
@@ -1,4 +1,5 @@
 module biocfd_initial_conditions
+  use iso_fortran_env, only : dp => real64
   ! allow(use-all) - TODO: Attempt to fix this in the future
   use global
   implicit none
@@ -8,61 +9,61 @@ module biocfd_initial_conditions
 
   contains
       SUBROUTINE initialConditions
-       INTEGER, PARAMETER :: rk = selected_real_kind(8)
+
        INTEGER::  i, j, k, n, f
         WRITE(*,*) 'Enter initialcondtitions'
        !cell variables
         DO i=1,nblocks
         block(i)%u = uc
          block(i)%ut = uc
-         block(i)%v = 0._rk
-         block(i)%vt = 0._rk
-        block(i)%w = 0._rk
-        block(i)%wt = 0._rk
-        block(i)%p = 0._rk
-        block(i)%u2_sum = 0._rk
-        block(i)%v2_sum = 0._rk
-        block(i)%w2_sum = 0._rk
-        block(i)%p2_sum = 0._rk
-        block(i)%u2_avg = 0._rk
-        block(i)%v2_avg = 0._rk
-        block(i)%w2_avg = 0._rk
-        block(i)%p2_avg = 0._rk
-        block(i)%u_sum = 0._rk
-        block(i)%v_sum = 0._rk
-        block(i)%w_sum = 0._rk
-        block(i)%p_sum = 0._rk
-        block(i)%uv_sum = 0._rk
-        block(i)%vw_sum = 0._rk
-        block(i)%uw_sum = 0._rk
-        block(i)%uv_avg = 0._rk
-        block(i)%vw_avg = 0._rk
-        block(i)%uw_avg = 0._rk
-        block(i)%u_avg = 0._rk
-        block(i)%v_avg = 0._rk
-        block(i)%w_avg = 0._rk
-        block(i)%p_avg = 0._rk
-        block(i)%ufl = 0._rk
-        block(i)%vfl = 0._rk
-        block(i)%wfl = 0._rk
-        block(i)%resi_u = 0._rk
-        block(i)%resi_v = 0._rk
-        block(i)%resi_w = 0._rk
+         block(i)%v = 0._dp
+         block(i)%vt = 0._dp
+        block(i)%w = 0._dp
+        block(i)%wt = 0._dp
+        block(i)%p = 0._dp
+        block(i)%u2_sum = 0._dp
+        block(i)%v2_sum = 0._dp
+        block(i)%w2_sum = 0._dp
+        block(i)%p2_sum = 0._dp
+        block(i)%u2_avg = 0._dp
+        block(i)%v2_avg = 0._dp
+        block(i)%w2_avg = 0._dp
+        block(i)%p2_avg = 0._dp
+        block(i)%u_sum = 0._dp
+        block(i)%v_sum = 0._dp
+        block(i)%w_sum = 0._dp
+        block(i)%p_sum = 0._dp
+        block(i)%uv_sum = 0._dp
+        block(i)%vw_sum = 0._dp
+        block(i)%uw_sum = 0._dp
+        block(i)%uv_avg = 0._dp
+        block(i)%vw_avg = 0._dp
+        block(i)%uw_avg = 0._dp
+        block(i)%u_avg = 0._dp
+        block(i)%v_avg = 0._dp
+        block(i)%w_avg = 0._dp
+        block(i)%p_avg = 0._dp
+        block(i)%ufl = 0._dp
+        block(i)%vfl = 0._dp
+        block(i)%wfl = 0._dp
+        block(i)%resi_u = 0._dp
+        block(i)%resi_v = 0._dp
+        block(i)%resi_w = 0._dp
         block(i)%cell_pr=0
-        block(i)%uflu_avg = 0._rk
-        block(i)%vflu_avg = 0._rk
-        block(i)%wflu_avg = 0._rk
-        block(i)%pflu_avg = 0._rk
-        block(i)%uflu_rms = 0._rk
-        block(i)%vflu_rms = 0._rk
-        block(i)%wflu_rms = 0._rk
-        block(i)%pflu_rms = 0._rk
-        block(i)%uvflu_avg = 0._rk
-        block(i)%vwflu_avg = 0._rk
-        block(i)%uwflu_avg = 0._rk
+        block(i)%uflu_avg = 0._dp
+        block(i)%vflu_avg = 0._dp
+        block(i)%wflu_avg = 0._dp
+        block(i)%pflu_avg = 0._dp
+        block(i)%uflu_rms = 0._dp
+        block(i)%vflu_rms = 0._dp
+        block(i)%wflu_rms = 0._dp
+        block(i)%pflu_rms = 0._dp
+        block(i)%uvflu_avg = 0._dp
+        block(i)%vwflu_avg = 0._dp
+        block(i)%uwflu_avg = 0._dp
         end do
-        SUMWSS = 0._rk            !SUMWSS global real array(nsurf)
-        SIGNWSS = 0._rk           !SIGNWSS global real array(nsurf)
+        SUMWSS = 0._dp            !SUMWSS global real array(nsurf)
+        SIGNWSS = 0._dp           !SIGNWSS global real array(nsurf)
         ita = 0
         ita1 = 0
         totime = 0.
@@ -73,10 +74,10 @@ module biocfd_initial_conditions
               k = block(f)%fluidIndexPtr(n, 3)
               block(f)% u(i,j,k)  = uc  !396.33054782262406 !116.236233
               block(f)%v(i,j,k)  = 0.
-              block(f)%w(i,j,k)  = 0._rk
+              block(f)%w(i,j,k)  = 0._dp
               block(f)%ut(i,j,k) = uc
-              block(f)%vt(i,j,k) = 0._rk
-              block(f)%wt(i,j,k) = 0._rk
+              block(f)%vt(i,j,k) = 0._dp
+              block(f)%wt(i,j,k) = 0._dp
           END DO
         END DO
 

--- a/src/LastConditions.f90
+++ b/src/LastConditions.f90
@@ -1,4 +1,5 @@
 module biocfd_last_conditions
+  use iso_fortran_env, only : dp => real64
   ! allow(use-all) - TODO: Aim to fix this in the future
   use global
   implicit none
@@ -8,26 +9,26 @@ module biocfd_last_conditions
 
   contains
       SUBROUTINE lastConditions
-       INTEGER, PARAMETER :: rk = selected_real_kind(8)
+
        INTEGER::  i, j, k, g
         CHARACTER(len=150) :: filename3
         WRITE(*,*) 'Enter lastcondtitions'
 
         DO g=1,nblocks
-        block(g)%u_sum = 0._rk
-        block(g)%v_sum = 0._rk
-        block(g)%w_sum = 0._rk
-        block(g)% p_sum = 0._rk
-        block(g)% u_avg = 0._rk
-        block(g)%v_avg = 0._rk
-        block(g)%w_avg = 0._rk
-        block(g)% p_avg = 0._rk
-        block(g)%resi_u = 0._rk
-        block(g)% resi_v = 0._rk
-        block(g)% resi_w = 0._rk
+        block(g)%u_sum = 0._dp
+        block(g)%v_sum = 0._dp
+        block(g)%w_sum = 0._dp
+        block(g)% p_sum = 0._dp
+        block(g)% u_avg = 0._dp
+        block(g)%v_avg = 0._dp
+        block(g)%w_avg = 0._dp
+        block(g)% p_avg = 0._dp
+        block(g)%resi_u = 0._dp
+        block(g)% resi_v = 0._dp
+        block(g)% resi_w = 0._dp
         END DO
-        SUMWSS = 0._rk            !SUMWSS global real array(nsurf)
-        SIGNWSS = 0._rk           !SIGNWSS global real array(nsurf)
+        SUMWSS = 0._dp            !SUMWSS global real array(nsurf)
+        SIGNWSS = 0._dp           !SIGNWSS global real array(nsurf)
         ita = 0
         ita1 = 0
         ita2 = 0

--- a/src/PcorVcor.f90
+++ b/src/PcorVcor.f90
@@ -15,19 +15,18 @@ module biocfd_pcor_vcor
       SUBROUTINE poissonSolver
 
         INTEGER(int64) :: i, j,k, n, g
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         REAL (dp)    :: max_derr1, max_derr2, max_div, max_derrStdSt
         REAL (dp)    :: er_dudt, er_dvdt, er_dwdt, err_ds
         INTEGER(int64) :: max_nIterPcor, max_nit
         CHARACTER(len=160) :: filename1
 
-          max_derrStdst=0._rk
-          max_derr1=0._rk
-          max_derr2=0._rk
+          max_derrStdst=0._dp
+          max_derr1=0._dp
+          max_derr2=0._dp
           max_nIterPcor=0
-          max_div=0._rk
-          max_nit=0._rk
-          err_ds=0._rk
+          max_div=0._dp
+          max_nit=0._dp
+          err_ds=0._dp
           er_dudt=0.
           er_dvdt=0.
           er_dwdt=0.
@@ -47,8 +46,8 @@ module biocfd_pcor_vcor
         END DO
         !$acc end parallel
         block(g)%nIterPcor=0
-        block(g)%derr2  = 0._rk
-        block(g)%derrStdSt=0._rk
+        block(g)%derr2  = 0._dp
+        block(g)%derrStdSt=0._dp
         block(g)%rhs=0.0
         end do
 
@@ -237,7 +236,6 @@ module biocfd_pcor_vcor
 
       SUBROUTINE REDBLACKSOR_linear(g)
 
-         INTEGER, PARAMETER :: rk = selected_real_kind(8)
          INTEGER(int64) :: n, i, j, k, gg, nx_var, ny_var,nz_var,nxy
          REAL (dp) :: errSum,var,derr4
          INTEGER(int64),INTENT(IN) ::g
@@ -259,8 +257,8 @@ module biocfd_pcor_vcor
 
         derr4=11111.
          nxy= nx_var * ny_var
-         block(g)%derr2 = 0._rk
-         errSum = 0._rk
+         block(g)%derr2 = 0._dp
+         errSum = 0._dp
  3       block(g)%nIterPcor=block(g)%nIterPcor+1
 
         var=0.
@@ -280,7 +278,7 @@ module biocfd_pcor_vcor
               -block(gg)%Acz(k-1,1)*block(gg)%pco(i,j,k-1) &
               -block(gg)%Acz(k-1,3)*block(gg)%pco(i,j,k+1)) / &
               (block(gg)%Acx(i-1,2)+block(gg)%Acy(j-1,2)+block(gg)%Acz(k-1,2))
-            block(gg)%pc(i,j,k) = (1._rk-omega)*block(gg)%pco(i,j,k) +omega*block(gg)%pc(i,j,k)
+            block(gg)%pc(i,j,k) = (1._dp-omega)*block(gg)%pco(i,j,k) +omega*block(gg)%pc(i,j,k)
 
  10      CONTINUE
         !$omp end parallel do
@@ -301,7 +299,7 @@ module biocfd_pcor_vcor
               -block(gg)%Acz(k-1,1)*block(gg)%pc(i,j,k-1) &
               -block(gg)%Acz(k-1,3)*block(gg)%pc(i,j,k+1)) / &
               (block(gg)%Acx(i-1,2)+block(gg)%Acy(j-1,2)+block(gg)%Acz(k-1,2))
-            block(gg)%pc(i,j,k) = (1._rk-omega)*block(gg)%pco(i,j,k) +omega*block(gg)%pc(i,j,k)
+            block(gg)%pc(i,j,k) = (1._dp-omega)*block(gg)%pco(i,j,k) +omega*block(gg)%pc(i,j,k)
 
  20      CONTINUE
         !$omp end parallel do

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -46,18 +46,17 @@ module biocfd_search
         end subroutine findDistnode
 
      SUBROUTINE shiftSurfaceNodesInitial
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER(int64) ::  i, g
         REAL(dp)      ::  xr1, yr1, zr1, angt
         REAL(dp)      :: bdy,bdfr
 
-        phase_angle = phase_angle*pi/180_rk
-        aoa1 = aoa*pi/180_rk
+        phase_angle = phase_angle*pi/180_dp
+        aoa1 = aoa*pi/180_dp
         aoa2 = -aoa1
-        alpha_m = alpha_m*pi/180_rk
-        theta_m = theta_m*pi/180_rk
+        alpha_m = alpha_m*pi/180_dp
+        theta_m = theta_m*pi/180_dp
         a0y = 0.  !a0y
-        ang_theta = 0.  !2._rk*pi*freq
+        ang_theta = 0.  !2._dp*pi*freq
         alpha_t=(alpha_m*0.5_dp)*(1+cos(ang_theta*(totime+deltat)+phase_angle))
         theta_t       =  theta_m*cos(ang_theta*(totime+deltat))
         DO g=blk_start,nblocks
@@ -69,7 +68,7 @@ module biocfd_search
         xfact=0.05_dp
         bdfr=15
         bdy=15*dxmin
-        angt  =  2._rk*pi*bdfr
+        angt  =  2._dp*pi*bdfr
 
         ac_x_al=0.
         ac_y_al=0.
@@ -88,8 +87,8 @@ module biocfd_search
         block(g)%ymove = 0.
         block(g)%zmove = 0.
 
-        block(g)%a0 = block(g)%a0*pi/180_rk
-         angt  =  2._rk*pi*block(g)%bfreq
+        block(g)%a0 = block(g)%a0*pi/180_dp
+         angt  =  2._dp*pi*block(g)%bfreq
          block(g)%xpth1=block(g)%xshift-(ita*dxmin*xfact)
         block(g)%xpth2=block(g)%xshift-(ita*dxmin*xfact)
         block(g)%ypth1=(block(g)%yamp)*sin(angt*block(g)%xshift)
@@ -99,29 +98,29 @@ module biocfd_search
         block(g)%piv_z = block(g)%zshift
 
         block(g)%thetaDot  =  0.
-        block(g)% thetaDDot =  0._rk
-        block(g)% thetaDot   =  0.  !ang_theta*a0*cos(2._rk*pi*freq*totime + phase_angle)
+        block(g)% thetaDDot =  0._dp
+        block(g)% thetaDot   =  0.  !ang_theta*a0*cos(2._dp*pi*freq*totime + phase_angle)
         block(g)%thetaDot1  = 0.
         block(g)% thetaDot2  = 0.
         block(g)% alphaDot  = 0.
-        block(g)%alphaDDot  = 0.  !-ang_theta*ang_theta*a0*sin(2._rk*pi*freq*totime + phase_angle)
+        block(g)%alphaDDot  = 0.  !-ang_theta*ang_theta*a0*sin(2._dp*pi*freq*totime + phase_angle)
         block(g)% thetaDDot1 = 0.
         block(g)%thetaDDot2 = 0.
-        block(g)% thetaDDot  = 0.  !-ang_theta*ang_theta*a0*sin(2._rk*pi*freq*totime + phase_angle)
+        block(g)% thetaDDot  = 0.  !-ang_theta*ang_theta*a0*sin(2._dp*pi*freq*totime + phase_angle)
        block(g)%yt         =  bdy*sin(2*pi*bdfr*totime )
        block(g)%ydot       =  angt*bdy*cos(2*pi*bdfr*totime)
        block(g)%yddot      =  -angt*angt*bdy*sin(2*pi*bdfr*totime)
        block(g)%xt         =  block(g)%xshift- (ita*dxmin*xfact)
        block(g)%xdot       =  -(dxmin*xfact)/deltat
        block(g)%xddot      =  0.
-        block(g)%u_prev = 0._rk
-        block(g)%u_curr = 0._rk
-        block(g)%v_prev = 0._rk
-        block(g)%v_curr = 0._rk
-        block(g)%w_prev = 0._rk
-        block(g)%w_curr = 0._rk
-        block(g)%Total_VP_FY = 0._rk
-        block(g)%Total_VP_FX = 0._rk
+        block(g)%u_prev = 0._dp
+        block(g)%u_curr = 0._dp
+        block(g)%v_prev = 0._dp
+        block(g)%v_curr = 0._dp
+        block(g)%w_prev = 0._dp
+        block(g)%w_curr = 0._dp
+        block(g)%Total_VP_FY = 0._dp
+        block(g)%Total_VP_FX = 0._dp
         block(g)%inity_cent=block(g)%yshift
         block(g)%nxty_cent=block(g)%yshift
         block(g)%initx_cent=block(g)%xshift
@@ -157,7 +156,6 @@ module biocfd_search
 
       SUBROUTINE computeSurfaceVariables
 
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER(int64) ::  i, g
         REAL(dp)      ::  xr1, yr1, zr1
         REAL(dp)      :: angg, angt
@@ -166,12 +164,12 @@ module biocfd_search
 
         DO g=blk_start,nblocks
         angg=90
-        aoa1       =  (block(g)%a0)*sin(2._rk*pi*freq*(totime+deltat) + phase_angle)
+        aoa1       =  (block(g)%a0)*sin(2._dp*pi*freq*(totime+deltat) + phase_angle)
         aoa2       = -aoa1
-        ang_theta  =  2._rk*pi*freq
+        ang_theta  =  2._dp*pi*freq
         bdfr=block(g)%bfreq
         bdy=block(g)%yamp
-        angt  =  2._rk*pi*bdfr
+        angt  =  2._dp*pi*bdfr
 
         block(g)%xpth2=block(g)%xshift-(ita*dxmin*xfact)
         block(g)%ypth2=(block(g)%yamp)*sin(angt*block(g)%xpth2)
@@ -179,8 +177,8 @@ module biocfd_search
         block(g)%ypth1=block(g)%ypth2
         block(g)%xpth1=block(g)%xpth2
         PRINT*, "angles =", aoa1*180._dp/pi, aoa2*180._dp/pi
-        block(g)%thetaDot1 = ang_theta*block(g)%a0*cos(2._rk*pi*freq*(totime+deltat) + phase_angle)
-        block(g)%thetaDDot1 = -ang_theta*ang_theta*block(g)%a0*sin(2._rk*pi*freq*(totime+deltat) &
+        block(g)%thetaDot1 = ang_theta*block(g)%a0*cos(2._dp*pi*freq*(totime+deltat) + phase_angle)
+        block(g)%thetaDDot1 = -ang_theta*ang_theta*block(g)%a0*sin(2._dp*pi*freq*(totime+deltat) &
                               + phase_angle)
         block(g)%thetaDot2  = -block(g)%thetaDot1
         block(g)%thetaDDot2 = -block(g)%thetaDDot1
@@ -241,7 +239,6 @@ module biocfd_search
 
       SUBROUTINE computeSurfaceNorm
 
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER(int64) ::  n, g  !c1, c2, c3, c4
         REAL(dp)      :: p1x, p1y, p1z, p2x, p2y, p2z, p3x, p3y, p3z, lenEL, binor
         REAL(dp)      :: var_xcent, var_ycent, var_zcent
@@ -271,9 +268,9 @@ module biocfd_search
            p3z = block(g)%znode1(block(g)%ibElP3(n))                       !z coordinate element node 3
 
 
-           var_xcent =  (p2x+p1x+p3x)/3._rk                  !centroid x coordinate element
-           var_ycent =  (p2y+p1y+p3y)/3._rk                  !centroid y coordinate element
-           var_zcent =  (p2z+p1z+p3z)/3._rk                  !centroid z coordinate element
+           var_xcent =  (p2x+p1x+p3x)/3._dp                  !centroid x coordinate element
+           var_ycent =  (p2y+p1y+p3y)/3._dp                  !centroid y coordinate element
+           var_zcent =  (p2z+p1z+p3z)/3._dp                  !centroid z coordinate element
 
            block(g)%xcent(n) =  var_xcent                  !centroid x coordinate element
            block(g)%ycent(n) =  var_ycent                  !centroid y coordinate element
@@ -306,7 +303,6 @@ module biocfd_search
 
      SUBROUTINE tagging_th
 
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER(int64) :: g, n, m, i, j, k,  nel2Cen, nel2Pnt, sumNodeId
         REAL(dp)      :: n1x, n1y, n1z, n2x, n2y, n2z, minDis1, minDis, &
                          n2dotn, cent_x, cent_y, cent_z, dis_cen, dis_pnt
@@ -487,9 +483,7 @@ module biocfd_search
 
      SUBROUTINE tagging_th_move
 
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER(int64) :: g, m, i, j, k, nel2Cen, nel2Pnt, sumNodeId
-
         INTEGER            :: a_blk_no, b_blk_no
         REAL(dp)      :: n1x, n1y, n1z, n2x,n2y,n2z, minDis1, minDis, &
                               n2dotn, cent_x, cent_y, cent_z, dis_cen, dis_pnt
@@ -614,7 +608,6 @@ module biocfd_search
 
      SUBROUTINE findTScells
 
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER            :: g,i, j, k, i1, j1, k1, iPt1, m, n, tscnt
 
 
@@ -730,7 +723,6 @@ module biocfd_search
 
      SUBROUTINE selectiveRetagging_th
 
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER(int64) ::  n, g, m, i, j, k, i1, j1, k1, nn, &
                                nel2Pnt, nel2Cen, sumNodeID
         INTEGER            :: flcnt, sdcnt, ibcnt
@@ -859,7 +851,6 @@ block(g)%fluidCellCount = flcnt
 
      SUBROUTINE cellCount_solid
 
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER (int64) ::  n, iPt, iPt1, iPt2, i, j, k, g
 
         print*, "cellCount started"
@@ -941,7 +932,6 @@ block(g)%fluidCellCount = flcnt
 
      SUBROUTINE computeNormDistance
 
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER            ::  nel2u1, nel2u2, nel2v1, nel2v2, nel2w1, nel2w2
         INTEGER            :: k, nel2p, g, ibxx, m
         REAL(dp) :: n1x, n2x, n3x, n1y, n2y, n3y, n1z, n2z, n3z, &
@@ -1118,7 +1108,6 @@ block(g)%fluidCellCount = flcnt
 
         SUBROUTINE cellCount_solid_coarse_mv
 
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER(int64) ::  n, iPt, iPt1, iPt2, i, j, k
         INTEGER(int64) ::  g
         g=1
@@ -1411,7 +1400,6 @@ block(g)%fluidCellCount = flcnt
         INTEGER(int64) :: i,j,k,g, a_blk_no, b_blk_no,countx_st,countz_st,county_st
         REAL(dp) :: change_y_f,change_x_f
         REAL(dp) :: change_z_f
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         DO g=blk_start,nblocks
 
         if ( block(g)% move_check == 1) then
@@ -1450,19 +1438,19 @@ block(g)%fluidCellCount = flcnt
         ENDDO
 
         DO i = 1, block(g)%ny+2
-           block(g)%yu(i) = 0.5_rk*(block(g)%y1(i)+block(g)%y1(i+1))
+           block(g)%yu(i) = 0.5_dp*(block(g)%y1(i)+block(g)%y1(i+1))
            block(g)%yw(i) = block(g)%yu(i)
            block(g)%yp(i) = block(g)%yu(i)
         END DO
 
         DO i = 1, block(g)%nx+2
-           block(g)%xv(i) = 0.5_rk*(block(g)%x1(i)+block(g)%x1(i+1))
+           block(g)%xv(i) = 0.5_dp*(block(g)%x1(i)+block(g)%x1(i+1))
            block(g)%xw(i) = block(g)%xv(i)
            block(g)%xp(i) = block(g)%xv(i)
         END DO
 
         DO i = 1, block(g)%nz+2
-           block(g)%zu(i) = 0.5_rk*(block(g)%z1(i)+block(g)%z1(i+1))
+           block(g)%zu(i) = 0.5_dp*(block(g)%z1(i)+block(g)%z1(i+1))
            block(g)%zv(i) = block(g)%zu(i)
            block(g)%zp(i) = block(g)%zu(i)
         END DO
@@ -1599,7 +1587,6 @@ block(g)%fluidCellCount = flcnt
         SUBROUTINE change_block_interface
 
         INTEGER(int64) :: i,j,g, a_blk_no, b_blk_no, factor
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
 
 
 
@@ -1845,7 +1832,6 @@ block(g)%fluidCellCount = flcnt
 
         SUBROUTINE cellCount_solid_coarse
 
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER (int64) ::  n, iPt, iPt1, iPt2, i, j, k
         INTEGER (int64) ::  g
         g=1

--- a/src/WriteOutput_corner1.f90
+++ b/src/WriteOutput_corner1.f90
@@ -10,7 +10,6 @@ module biocfd_write_output_corner1
 
 contains
       SUBROUTINE writeOutput1
-       INTEGER, PARAMETER :: rk = selected_real_kind(8)
        CHARACTER(len=150)  :: filename1
        INTEGER  :: k, i, j, g
        REAL (dp) :: u1, v1, w1
@@ -41,7 +40,6 @@ contains
       END SUBROUTINE writeOutput1
 
       SUBROUTINE writeResult
-        INTEGER, PARAMETER :: rk = selected_real_kind(8)
         INTEGER::  i, j, k,g
        CHARACTER(len=70)  :: filename1
         IF(mod(ita,500)==0)THEN


### PR DESCRIPTION
Allows us to add the `-Werror=unused-parameter` flag (even if we don't think this catches everything). See #47.