### PR TITLE
Remove assignment of unallocated arrays

### DIFF
--- a/src/InitialConditions.f90
+++ b/src/InitialConditions.f90
@@ -58,12 +58,9 @@ module biocfd_initial_conditions
         block(i)%vflu_rms = 0._dp
         block(i)%wflu_rms = 0._dp
         block(i)%pflu_rms = 0._dp
-        block(i)%uvflu_avg = 0._dp
-        block(i)%vwflu_avg = 0._dp
-        block(i)%uwflu_avg = 0._dp
         end do
-        SUMWSS = 0._dp            !SUMWSS global real array(nsurf)
-        SIGNWSS = 0._dp           !SIGNWSS global real array(nsurf)
+        ! SUMWSS = 0._dp            !SUMWSS global real array(nsurf)
+        ! SIGNWSS = 0._dp           !SIGNWSS global real array(nsurf)
         ita = 0
         ita1 = 0
         totime = 0.

--- a/src/LastConditions.f90
+++ b/src/LastConditions.f90
@@ -27,8 +27,8 @@ module biocfd_last_conditions
         block(g)% resi_v = 0._dp
         block(g)% resi_w = 0._dp
         END DO
-        SUMWSS = 0._dp            !SUMWSS global real array(nsurf)
-        SIGNWSS = 0._dp           !SIGNWSS global real array(nsurf)
+        ! SUMWSS = 0._dp            !SUMWSS global real array(nsurf)
+        ! SIGNWSS = 0._dp           !SIGNWSS global real array(nsurf)
         ita = 0
         ita1 = 0
         ita2 = 0

--- a/src/PcorVcor.f90
+++ b/src/PcorVcor.f90
@@ -48,7 +48,6 @@ module biocfd_pcor_vcor
         block(g)%nIterPcor=0
         block(g)%derr2  = 0._dp
         block(g)%derrStdSt=0._dp
-        block(g)%rhs=0.0
         end do
 
         solverTime=0.

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -87,7 +87,7 @@ MODULE global
         REAL (dp), ALLOCATABLE, DIMENSION (:) ::dataval
         INTEGER (int32)   :: nnz,nu, nit, nit1
         INTEGER (int32), ALLOCATABLE, DIMENSION (:) :: row_ptr,col
-        REAL (dp), ALLOCATABLE, DIMENSION (:) ::rhs,sol
+        REAL (dp), ALLOCATABLE, DIMENSION (:) :: sol
         INTEGER (int32) :: crs_data(4)
          integer(int32) :: diag(7)
 

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -72,7 +72,6 @@ MODULE global
                                                       uv_avg,vw_avg,uw_avg, &
                                                       uflu_avg,vflu_avg,wflu_avg,pflu_avg, &
                                                       uflu_rms,vflu_rms,wflu_rms,pflu_rms, &
-                                                      uvflu_avg,vwflu_avg,uwflu_avg, &
                                                       u2_sum,v2_sum,w2_sum,p2_sum,  &
                                                       u2_avg,v2_avg,w2_avg,p2_avg,  &
                                                       ufl,vfl,wfl,  &


### PR DESCRIPTION
The `uvflu_avg`, `vwflu_avg`, and `uwflu_avg` are set to 0 in initial conditions but the arrays are never allocated. When building/running with `gfortran`, this produces a segfault. I'm a bit confused what `nvfortran` does such that this doesn't happen, but it is definitely not the intended behaviour. 

These variables aren't used anywhere at all so I'm removing them completely. 

The `SUMWSS` and `SIGNWSS` variables are a similar situation. I'm just commenting these for now pending discussion with the team.

Edit:
I've found another case where this happens, with the `rhs` member variable of Blocks. I've removed it.