### PR TITLE
WIP (DO NOT MERGE): Add tagging_th OpenMP directives and small refactor

### DIFF
--- a/src/Search.f90
+++ b/src/Search.f90
@@ -304,7 +304,7 @@ module biocfd_search
      SUBROUTINE tagging_th
 
         INTEGER(int64) :: g, n, m, i, j, k,  nel2Cen, nel2Pnt, sumNodeId
-        REAL(dp)      :: n1x, n1y, n1z, n2x, n2y, n2z, minDis1, minDis, &
+        REAL(dp)      :: minDis1, minDis, &
                          n2dotn, cent_x, cent_y, cent_z, dis_cen, dis_pnt
 
         CHARACTER(LEN=120) :: filename1
@@ -318,27 +318,23 @@ module biocfd_search
         n2dotn = 0
 
  !$acc parallel loop collapse(3) default(present)
+        !$omp parallel do default(none) private(minDis, minDis1) &
+        !$omp& private(cent_x, cent_y, cent_z) &
+        !$omp& private(dis_cen, dis_pnt, nel2Cen, nel2Pnt, n2dotn) &
+        !$omp& shared(g, block)
         DO k = block(g)%k_startSearch, block(g)%k_endSearch
         DO j = block(g)%j_startSearch, block(g)%j_endSearch
         DO i = block(g)%i_startSearch, block(g)%i_endSearch
             minDis  = 1e14_dp
             minDis1 = 1e14_dp
 
-            n1x = block(g)%xp(i)
-            n1y = block(g)%yp(j)
-            n1z = block(g)%zp(k)
-
-            n2x = block(g)%x1(i)
-            n2y = block(g)%y1(j)
-            n2z = block(g)%z1(k)
-
             !$acc loop seq
             DO m = 1, block(g)%ibElems
             cent_x = block(g)%xcent(m)
             cent_y = block(g)%ycent(m)
             cent_z = block(g)%zcent(m)
-               dis_cen  = dsqrt( (n1y-cent_y)**2 + (n1x-cent_x)**2  + (n1z-cent_z)**2)
-               dis_pnt  = dsqrt( (n2y-cent_y)**2 + (n2x-cent_x)**2  + (n2z-cent_z)**2)
+               dis_cen  = dsqrt( (block(g)%yp(j)-cent_y)**2 + (block(g)%xp(i)-cent_x)**2  + (block(g)%zp(k)-cent_z)**2)
+               dis_pnt  = dsqrt( (block(g)%y1(j)-cent_y)**2 + (block(g)%x1(i)-cent_x)**2  + (block(g)%z1(k)-cent_z)**2)
                IF (dis_cen<minDis) THEN
                   minDis    = dis_cen
                   nel2Cen   = m
@@ -358,9 +354,9 @@ module biocfd_search
 
             ENDIF
 
-                        n2dotn  = (n2x - block(g)%xcent(nel2Pnt))*block(g)%cosAlpha(nel2Pnt) + &
-                           (n2y - block(g)%ycent(nel2Pnt))*block(g)%cosBeta(nel2Pnt)  + &
-                           (n2z - block(g)%zcent(nel2Pnt))*block(g)%cosGamma(nel2Pnt)
+            n2dotn  = (block(g)%x1(i) - block(g)%xcent(nel2Pnt))*block(g)%cosAlpha(nel2Pnt) + &
+                      (block(g)%y1(j) - block(g)%ycent(nel2Pnt))*block(g)%cosBeta(nel2Pnt)  + &
+                      (block(g)%z1(k) - block(g)%zcent(nel2Pnt))*block(g)%cosGamma(nel2Pnt)
 
             IF (n2dotn>=-1e-16_dp) THEN
                block(g)%nodeIdTag(i,j,k) = 0
@@ -370,6 +366,7 @@ module biocfd_search
          END DO
          END DO
          END DO
+         !$omp end parallel do
 !$acc end parallel
 
 !$acc parallel loop collapse(3) default(present)

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -303,7 +303,7 @@ module biocfd_search
 
      SUBROUTINE tagging_th
 
-        INTEGER(int64) :: g, n, m, i, j, k,  nel2Cen, nel2Pnt, sumNodeId
+        INTEGER(int64) :: g, n, i, j, k,  nel2Cen, nel2Pnt, sumNodeId
         REAL(dp)      :: n2dotn
         !> This temporary array holds distance calculations
         real(dp), allocatable, dimension(:) :: temp_var
@@ -324,29 +324,14 @@ module biocfd_search
         DO k = block(g)%k_startSearch, block(g)%k_endSearch
         DO j = block(g)%j_startSearch, block(g)%j_endSearch
         DO i = block(g)%i_startSearch, block(g)%i_endSearch
-            ! minDis  = 1e14_dp
-            ! minDis1 = 1e14_dp
 
-            temp_var = dsqrt( (block(g)%yp(j)-block(g)%ycent)**2 + (block(g)%xp(i)-block(g)%xcent)**2  + (block(g)%zp(k)-block(g)%zcent)**2)
+            ! There is no need to take the sqrt of these distances as we just want the minimum
+            temp_var = (block(g)%yp(j)-block(g)%ycent)**2 + (block(g)%xp(i)-block(g)%xcent)**2 &
+                     + (block(g)%zp(k)-block(g)%zcent)**2
             nel2cen = minloc(temp_var, dim=1)
-            temp_var = dsqrt( (block(g)%y1(j)-block(g)%ycent)**2 + (block(g)%x1(i)-block(g)%xcent)**2  + (block(g)%z1(k)-block(g)%zcent)**2)
+            temp_var = (block(g)%y1(j)-block(g)%ycent)**2 + (block(g)%x1(i)-block(g)%xcent)**2 &
+                     + (block(g)%z1(k)-block(g)%zcent)**2
             nel2pnt = minloc(temp_var, dim=1)
-            ! !$acc loop seq
-            ! DO m = 1, block(g)%ibElems
-            ! cent_x = block(g)%xcent(m)
-            ! cent_y = block(g)%ycent(m)
-            ! cent_z = block(g)%zcent(m)
-            !    dis_cen  = dsqrt( (block(g)%yp(j)-cent_y)**2 + (block(g)%xp(i)-cent_x)**2  + (block(g)%zp(k)-cent_z)**2)
-            !    dis_pnt  = dsqrt( (block(g)%y1(j)-cent_y)**2 + (block(g)%x1(i)-cent_x)**2  + (block(g)%z1(k)-cent_z)**2)
-            !    IF (dis_cen<minDis) THEN
-            !       minDis    = dis_cen
-            !       nel2Cen   = m
-            !    ENDIF
-            !    IF (dis_pnt<minDis1) THEN
-            !       minDis1   = dis_pnt
-            !       nel2Pnt   = m
-            !    ENDIF
-            ! ENDDO
 
             IF((block(g)%x1(i)<=block(g)%xcent(nel2Cen) .AND. &
                 block(g)%x1(i+1)>=block(g)%xcent(nel2Cen)).AND. &

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -320,7 +320,9 @@ module biocfd_search
         allocate(temp_var(block(g)%ibElems))
 
  !$acc parallel loop collapse(3) default(present)
-        !$omp parallel do default(none) private(nel2Cen, nel2Pnt, n2dotn, temp_var) shared(g, block)
+        !$omp parallel default(none)  &
+        !$omp& private(nel2Cen, nel2Pnt, n2dotn, temp_var, sumNodeId) shared(g, block)
+        !$omp do collapse(3)
         DO k = block(g)%k_startSearch, block(g)%k_endSearch
         DO j = block(g)%j_startSearch, block(g)%j_endSearch
         DO i = block(g)%i_startSearch, block(g)%i_endSearch
@@ -355,12 +357,12 @@ module biocfd_search
          END DO
          END DO
          END DO
-         !$omp end parallel do
+         !$omp end do
+
 !$acc end parallel
 
-         deallocate(temp_var)
-
 !$acc parallel loop collapse(3) default(present)
+           !$omp do collapse(3)
            DO k = block(g)%k_startSearch, block(g)%k_endSearch
            DO j = block(g)%j_startSearch, block(g)%j_endSearch
            DO i = block(g)%i_startSearch, block(g)%i_endSearch
@@ -377,7 +379,11 @@ module biocfd_search
            END DO
            END DO
            END DO
+           !$omp end do
 !$acc end parallel
+           !$omp end parallel
+
+          deallocate(temp_var)
 
 
          WRITE(filename1,1) g

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -304,9 +304,9 @@ module biocfd_search
      SUBROUTINE tagging_th
 
         INTEGER(int64) :: g, n, m, i, j, k,  nel2Cen, nel2Pnt, sumNodeId
-        REAL(dp)      :: minDis1, minDis, &
-                         n2dotn, cent_x, cent_y, cent_z, dis_cen, dis_pnt
-
+        REAL(dp)      :: n2dotn
+        !> This temporary array holds distance calculations
+        real(dp), allocatable, dimension(:) :: temp_var
         CHARACTER(LEN=120) :: filename1
         DO g=blk_start, nblocks
         block(g)%ibCellCount = 0
@@ -317,33 +317,37 @@ module biocfd_search
         block(g)%nodeIdTag = 0
         n2dotn = 0
 
+        allocate(temp_var(block(g)%ibElems))
+
  !$acc parallel loop collapse(3) default(present)
-        !$omp parallel do default(none) private(minDis, minDis1) &
-        !$omp& private(cent_x, cent_y, cent_z) &
-        !$omp& private(dis_cen, dis_pnt, nel2Cen, nel2Pnt, n2dotn) &
-        !$omp& shared(g, block)
+        !$omp parallel do default(none) private(nel2Cen, nel2Pnt, n2dotn, temp_var) shared(g, block)
         DO k = block(g)%k_startSearch, block(g)%k_endSearch
         DO j = block(g)%j_startSearch, block(g)%j_endSearch
         DO i = block(g)%i_startSearch, block(g)%i_endSearch
-            minDis  = 1e14_dp
-            minDis1 = 1e14_dp
+            ! minDis  = 1e14_dp
+            ! minDis1 = 1e14_dp
 
-            !$acc loop seq
-            DO m = 1, block(g)%ibElems
-            cent_x = block(g)%xcent(m)
-            cent_y = block(g)%ycent(m)
-            cent_z = block(g)%zcent(m)
-               dis_cen  = dsqrt( (block(g)%yp(j)-cent_y)**2 + (block(g)%xp(i)-cent_x)**2  + (block(g)%zp(k)-cent_z)**2)
-               dis_pnt  = dsqrt( (block(g)%y1(j)-cent_y)**2 + (block(g)%x1(i)-cent_x)**2  + (block(g)%z1(k)-cent_z)**2)
-               IF (dis_cen<minDis) THEN
-                  minDis    = dis_cen
-                  nel2Cen   = m
-               ENDIF
-               IF (dis_pnt<minDis1) THEN
-                  minDis1   = dis_pnt
-                  nel2Pnt   = m
-               ENDIF
-            ENDDO
+            temp_var = dsqrt( (block(g)%yp(j)-block(g)%ycent)**2 + (block(g)%xp(i)-block(g)%xcent)**2  + (block(g)%zp(k)-block(g)%zcent)**2)
+            nel2cen = minloc(temp_var, dim=1)
+            temp_var = dsqrt( (block(g)%y1(j)-block(g)%ycent)**2 + (block(g)%x1(i)-block(g)%xcent)**2  + (block(g)%z1(k)-block(g)%zcent)**2)
+            nel2pnt = minloc(temp_var, dim=1)
+            ! !$acc loop seq
+            ! DO m = 1, block(g)%ibElems
+            ! cent_x = block(g)%xcent(m)
+            ! cent_y = block(g)%ycent(m)
+            ! cent_z = block(g)%zcent(m)
+            !    dis_cen  = dsqrt( (block(g)%yp(j)-cent_y)**2 + (block(g)%xp(i)-cent_x)**2  + (block(g)%zp(k)-cent_z)**2)
+            !    dis_pnt  = dsqrt( (block(g)%y1(j)-cent_y)**2 + (block(g)%x1(i)-cent_x)**2  + (block(g)%z1(k)-cent_z)**2)
+            !    IF (dis_cen<minDis) THEN
+            !       minDis    = dis_cen
+            !       nel2Cen   = m
+            !    ENDIF
+            !    IF (dis_pnt<minDis1) THEN
+            !       minDis1   = dis_pnt
+            !       nel2Pnt   = m
+            !    ENDIF
+            ! ENDDO
+
             IF((block(g)%x1(i)<=block(g)%xcent(nel2Cen) .AND. &
                 block(g)%x1(i+1)>=block(g)%xcent(nel2Cen)).AND. &
                (block(g)%y1(j)<=block(g)%ycent(nel2Cen) .AND. &
@@ -368,6 +372,8 @@ module biocfd_search
          END DO
          !$omp end parallel do
 !$acc end parallel
+
+         deallocate(temp_var)
 
 !$acc parallel loop collapse(3) default(present)
            DO k = block(g)%k_startSearch, block(g)%k_endSearch


### PR DESCRIPTION
Should not be merged before #103. 

This PR makes the mistake of doing more than one thing. They are:

### 1. Add OMP directives to loops in `tagging_th`

Local tests using one iteration spend most the time in the `tagging_th` subroutine. Here I've added OpenMP directives to the most expensive loop. On my laptop (M1 Pro MacBook Pro with 10 cores) compiling using `gfortran` and `-fopenmp` allows me to run the code locally in a *reasonable* time (around 12 minutes for a single iteration)

### 2. Small refactor of most expensive loop of `tagging_th`

The main thrust of this loop is finding the closest elements to some central(?) value for each element in the mesh (to the best of my knowledge). Rather than looping through every element in an explicit loop, we can use the `minloc` intrinsic which is cleaner and empirically slightly faster. Further more, because we are just looking for a minimum, we don't actually need to perform a square root operation on the distance vector as the element with minimum^2 is the same as sqrt(minimum^2). Switching to this approach allows us to remove a bunch of variables and saves us another 2m30s of the time taken to run (total time now around 9m30s).

### Todo
- [ ] The `minloc` intrinsic is faster using OpenMP on my laptop, but I'd like to see what (if any) impact this has when generating code for Nvidia GPUs
- There are a bunch of subroutines that are almost identical to `tagging_th` and could benefit from the same improvements (or better, refactor to avoid repetition). They are
  - [ ] `tagging_th_move`
  - [ ] `selectiveRetagging_th`