### PR TITLE
dStart1 and dFinish1 are only used in main.f90

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -1,6 +1,6 @@
 
       PROGRAM main
-        use, intrinsic :: iso_fortran_env, only: int64
+        use, intrinsic :: iso_fortran_env, only: int64, dp => real64
         ! allow(use-all) - TODO: Aim to fix this in the future
         USE global
         use biocfd_search, only: findDistnode, shiftSurfaceNodesInitial, computeSurfaceNorm, &
@@ -23,6 +23,7 @@
         IMPLICIT NONE
 
         INTEGER (int64) :: g
+        real(dp) :: dstart1, dfinish1
         CALL readInput
         CALL readBlockInterface
         CALL readSurfaceMeshGmsh

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -15,7 +15,7 @@ MODULE global
                                 freq, &
                                 u0, v0, w0, p0,Uavg,  &
                                 eps1, epsi, epsDiv, re, rev, divmax,   &
-                                fx, fy,  alpha, pct, pct1, dstart1,dfinish1, &
+                                fx, fy,  alpha, pct, pct1, &
                                 xfact,deltat, coupTime,totime, totalTime, dfinish, dstart, &
                                 solverTime, pi , msTime, mindx, al, uc
 


### PR DESCRIPTION
A nice easy PR.

Two variables I've spotted `dStart1` and `dFinish1` are only used in `main.f90`, so no need for them to be declared in `modGlobal.f90`.