### PR TITLE
Fix termination of openacc directives

### DIFF
--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -37,8 +37,7 @@ jobs:
           - {compiler: gcc, version: 14, FPM_FFLAGS: "-fopenmp", tag: "-openmp"}
           - {compiler: nvidia-hpc, version: '25.1', FPM_FFLAGS: "-mp", tag: "-openmp"}
           # Compile with OpenACC since there are some directives
-          # TODO: Removing gcc with -fopenacc for now (see #102)
-          # - {compiler: gcc, version: 14, FPM_FFLAGS: "-fopenacc", tag: "-openacc"}
+          - {compiler: gcc, version: 14, FPM_FFLAGS: "-fopenacc", tag: "-openacc"}
           - {compiler: nvidia-hpc, version: '25.1', FPM_FFLAGS: "-acc=multicore", tag: "-openacc"}
           # lfortran can't compile the code at the moment, we will
           # keep an eye on the progress of the project in the hope

--- a/src/BoundaryConditions.f90
+++ b/src/BoundaryConditions.f90
@@ -14,7 +14,7 @@ SUBROUTINE velocityBC
 
       g=1
      !$acc parallel loop gang vector collapse (2) default(present)  &
-     !$acc firstprivate (uc, deltat, block(g)%nx)
+     !$acc firstprivate (uc, deltat)
       DO  k = 2, block(g)%nz+1
       DO  j = 2, block(g)%ny+1
         !uniform inlet
@@ -37,10 +37,9 @@ SUBROUTINE velocityBC
                                     uc*(block(g)%w(block(g)%nx+2,j,k)-block(g)%w(block(g)%nx+1,j,k))
         END DO
         END DO
-     !$acc end parallel
+     !$acc end parallel loop
 
-     !$acc parallel loop gang vector collapse (2) default(present) &
-     !$acc firstprivate (block(g)%ny)
+     !$acc parallel loop gang vector collapse (2) default(present)
       DO k = 2, block(g)%nz+1
       DO i = 2, block(g)%nx+1
 
@@ -56,10 +55,9 @@ SUBROUTINE velocityBC
 
         END DO
         END DO
-     !$acc end parallel
+     !$acc end parallel loop
 
-     !$acc parallel loop gang vector collapse (2) default(present) &
-     !$acc firstprivate (block(g)%nz)
+     !$acc parallel loop gang vector collapse (2) default(present)
       DO  j = 2, block(g)%ny+1
       DO  i = 2, block(g)%nx+1
          block(g)%ut(i,j,1) =  block(g)%ut(i,j,2)
@@ -72,7 +70,7 @@ SUBROUTINE velocityBC
 
       END DO
       END DO
-      !$acc end parallel
+      !$acc end parallel loop
       END SUBROUTINE velocityBC
 
       SUBROUTINE solidCellBC
@@ -90,7 +88,7 @@ SUBROUTINE velocityBC
             block(g)%wt(i,j,k) = 0._dp
             block(g)%p(i,j,k)  = 0._dp
          END DO
-        !$acc end parallel
+        !$acc end parallel loop
          END DO
       END SUBROUTINE solidCellBC
 
@@ -113,7 +111,7 @@ SUBROUTINE velocityBC
             block(g)%v(i,j,k) = 0._dp
             block(g)%w(i,j,k) = 0._dp
          END DO
-         !$acc end parallel
+         !$acc end parallel loop
         endif
       END SUBROUTINE solidCellBC_move
 

--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -27,8 +27,7 @@ SUBROUTINE pressureForcing1
  !$acc           dpdn_e, k, j, i, il, jl, kl, i_x1, i_y1,               &
  !$acc           i_z1,ac_z,ac_y,ac_x,at_y,at_z,ac_x_al,ac_y_al,at_x_al,at_y_al)         &
  !$acc default(present)  &
- !$acc private(derivatives) &
- !$acc firstprivate (block(g)%nx, block(g)%ny,block(g)%nz)
+ !$acc private(derivatives)
       DO n = 1, block(g)%ibCellCount
          IF (block(g)%ibSurfId(block(g)%nelp(n))==50) THEN
             !dpdn = 0.
@@ -102,7 +101,7 @@ SUBROUTINE pressureForcing1
 
          block(g)%p(i,j,k) = aval*sur2nodeDis**2 + bval*sur2nodeDis + cval
       ENDDO
- !$acc end parallel
+ !$acc end parallel loop
       ENDDO
 
 END SUBROUTINE pressureForcing1
@@ -134,8 +133,7 @@ SUBROUTINE velocityForcing1
  !$acc          dwdn_e, dwdx_e, dwdy_e, dwdz_e, u_x1_z1, u_x2_z1, u_x1_z2, u_x2_z2, u_z1_x1,  &
  !$acc          u_z2_x1, u_z1_x2, u_z2_x2, v_x1_z1, v_x2_z1, v_x1_z2, v_x2_z2, v_z1_x1, v_z2_x1, v_z1_x2, &
  !$acc          v_z2_x2, w_x1_z1, w_x2_z1, w_x1_z2, w_x2_z2, w_z1_x1, w_z2_x1, w_z1_x2, w_z2_x2, k, j, i, il, jl, kl, i_x1, i_y1, i_z1) &
- !$acc default(present)   &
- !$acc firstprivate (block(g)%nx, block(g)%ny,block(g)%nz)
+ !$acc default(present)
 
       DO n = 1, block(g)%ibCellCount
 
@@ -809,7 +807,7 @@ SUBROUTINE velocityForcing1
          avaL = dwdn_e/n1 - (w_pos1 - wsurf)/n1**2
          block(g)%wt(i,j,k-1) = aval*sur2nodeDis**2 + bval*sur2nodeDis + cval
       ENDDO
-!$acc end parallel
+!$acc end parallel loop
       ENDDO
 
 END SUBROUTINE velocityForcing1
@@ -830,8 +828,7 @@ SUBROUTINE pressureForcingGhost
  !$acc           p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1,                &
  !$acc           p_z1_x2, p_z2_x2, h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, k, j, i, il, jl, kl, i_x1, i_y1,               &
  !$acc           i_z1,ac_z,ac_y,ac_x,at_y,at_z,ac_x_al,ac_y_al,at_x_al,at_y_al)         &
- !$acc default(present)  &
- !$acc firstprivate (block(g)%nx, block(g)%ny,block(g)%nz)
+ !$acc default(present)
       DO n = 1, block(g)%TSCellCount
 
         i = block(g)%TSIndexPtr(n, 1)
@@ -975,7 +972,7 @@ SUBROUTINE pressureForcingGhost
          block(g)%p_ghost(n) = aval*sur2nodeDis**2 + bval*sur2nodeDis + cval
          block(g)%pt_ghost(n) = block(g)%p(i,j,k)
       ENDDO
-      !$acc end parallel
+      !$acc end parallel loop
       ENDDO
 END SUBROUTINE pressureForcingGhost
 
@@ -1004,8 +1001,7 @@ SUBROUTINE velocityForcingGhost
  !$acc          dwdn_e, dwdx_e, dwdy_e, dwdz_e, u_x1_z1, u_x2_z1, u_x1_z2, u_x2_z2, u_z1_x1,  &
  !$acc          u_z2_x1, u_z1_x2, u_z2_x2, v_x1_z1, v_x2_z1, v_x1_z2, v_x2_z2, v_z1_x1, v_z2_x1, v_z1_x2, &
  !$acc          v_z2_x2, w_x1_z1, w_x2_z1, w_x1_z2, w_x2_z2, w_z1_x1, w_z2_x1, w_z1_x2, w_z2_x2, k, j, i, il, jl, kl, i_x1, i_y1, i_z1) &
- !$acc default(present)   &
- !$acc firstprivate (block(g)%nx, block(g)%ny,block(g)%nz)
+ !$acc default(present)
       DO n = 1, block(g)%TSCellCount
 
         i = block(g)%TSIndexPtr(n, 1)
@@ -1699,7 +1695,7 @@ SUBROUTINE velocityForcingGhost
          block(g)%w1_ghost(n) = aval*sur2nodeDis**2 + bval*sur2nodeDis + cval
          block(g)%w1t_ghost(n) = block(g)%w(i,j,k-1)
       ENDDO
-      !$acc end parallel
+      !$acc end parallel loop
       ENDDO
 
 END SUBROUTINE velocityForcingGhost
@@ -1721,8 +1717,7 @@ SUBROUTINE pressureForcingField
  !$acc           p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1,                &
  !$acc           p_z1_x2, p_z2_x2, h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, k, j, i, il, jl, kl, i_x1, i_y1,               &
  !$acc           i_z1,ac_z,ac_y,ac_x,at_y,at_z,ac_x_al,ac_y_al,at_x_al,at_y_al)         &
- !$acc default(present)  &
- !$acc firstprivate (block(g)%nx, block(g)%ny,block(g)%nz)
+ !$acc default(present)
       DO n = 1, block(g)%ibCellCount
          IF (block(g)%ibSurfId(block(g)%nelp(n))==50) THEN
             ac_z = 0.  !-block(g)%thetaDot**2*(block(g)%zcent(block(g)%nelp(block(g)%index_ts(n))) - block(g)%piv_z)
@@ -1856,7 +1851,7 @@ SUBROUTINE pressureForcingField
 
          block(g)%p(i,j,k) = aval*sur2nodeDis**2 + bval*sur2nodeDis + cval
       ENDDO
-      !$acc end parallel
+      !$acc end parallel loop
       ENDDO
 END SUBROUTINE pressureForcingField
 
@@ -1887,8 +1882,7 @@ SUBROUTINE velocityForcingField
  !$acc          dwdn_e, dwdx_e, dwdy_e, dwdz_e, u_x1_z1, u_x2_z1, u_x1_z2, u_x2_z2, u_z1_x1,  &
  !$acc          u_z2_x1, u_z1_x2, u_z2_x2, v_x1_z1, v_x2_z1, v_x1_z2, v_x2_z2, v_z1_x1, v_z2_x1, v_z1_x2, &
  !$acc          v_z2_x2, w_x1_z1, w_x2_z1, w_x1_z2, w_x2_z2, w_z1_x1, w_z2_x1, w_z1_x2, w_z2_x2, k, j, i, il, jl, kl, i_x1, i_y1, i_z1) &
- !$acc default(present)   &
- !$acc firstprivate (block(g)%nx, block(g)%ny,block(g)%nz)
+ !$acc default(present)
       DO n = 1, block(g)%ibCellCount
 
          i = block(g)%interceptedIndexPtr(n, 1)
@@ -2560,7 +2554,7 @@ SUBROUTINE velocityForcingField
          avaL = dwdn_e/n1 - (w_pos1 - wsurf)/n1**2
          block(g)%w(i,j,k-1) = aval*sur2nodeDis**2 + bval*sur2nodeDis + cval
       ENDDO
-      !$acc end parallel
+      !$acc end parallel loop
       ENDDO
 
 END SUBROUTINE velocityForcingField

--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -1553,7 +1553,7 @@ IF (block(g)%cell2(i, j, k-1)==2) THEN
 ENDIF
        ENDDO
 !c***********************************************************************
-     !$acc end parallel
+     !$acc end parallel loop
         !$acc wait
 
        ENDDO

--- a/src/PcorVcor.f90
+++ b/src/PcorVcor.f90
@@ -44,7 +44,7 @@ module biocfd_pcor_vcor
         END DO
         END DO
         END DO
-        !$acc end parallel
+        !$acc end parallel loop
         block(g)%nIterPcor=0
         block(g)%derr2  = 0._dp
         block(g)%derrStdSt=0._dp
@@ -105,7 +105,7 @@ module biocfd_pcor_vcor
            er_dwdt = dabs((block(g)%wt(i,j,k) - block(g)%w(i,j,k)))/deltat
            err_ds = dmax1(err_ds, er_dudt,er_dvdt, er_dwdt)
          ENDDO
-         !$acc end parallel
+         !$acc end parallel loop
            block(g)%derrStdSt = err_ds
 
 
@@ -154,7 +154,7 @@ module biocfd_pcor_vcor
          END DO
          END DO
          END DO
-        !$acc end parallel
+        !$acc end parallel loop
         !$omp end parallel do
          END DO
         CALL fineUpdate_bd
@@ -182,7 +182,7 @@ module biocfd_pcor_vcor
              (block(gg)%wt(i,j,k) - block(gg)%wt(i,j,k-1))/block(gg)%deltaz(k)
 
          END DO
-        !$acc end parallel
+        !$acc end parallel loop
         !$omp end parallel do
 
       END SUBROUTINE computeDiv
@@ -202,7 +202,7 @@ module biocfd_pcor_vcor
             block(gg)%p(i,j,k) = block(gg)%p(i,j,k) + block(gg)%pc(i,j,k)
         END DO
         !$omp end parallel do
-        !$acc end parallel
+        !$acc end parallel loop
       END SUBROUTINE correctPressure
 
       SUBROUTINE correctVelocity(g)
@@ -229,7 +229,7 @@ module biocfd_pcor_vcor
                deltat/(0.5d0*(block(gg)%deltaz(k+1)+block(gg)%deltaz(k))) * &
                (block(gg)%pc(i,j,k+1)-block(gg)%pc(i,j,k))
  30      CONTINUE
-         !$acc end parallel
+         !$acc end parallel loop
         !$omp end parallel do
       END SUBROUTINE correctVelocity
 
@@ -281,7 +281,7 @@ module biocfd_pcor_vcor
 
  10      CONTINUE
         !$omp end parallel do
-        !$acc end parallel
+        !$acc end parallel loop
 
         !$acc parallel loop gang vector default(present) firstprivate(deltat, omega) private (i, j, k)
         !$omp parallel do private (i,j,k,n) num_threads(48)
@@ -302,7 +302,7 @@ module biocfd_pcor_vcor
 
  20      CONTINUE
         !$omp end parallel do
-        !$acc end parallel
+        !$acc end parallel loop
 
 
        if(mod(block(gg)%nIterPcor,5_int64) ==0)then
@@ -317,7 +317,7 @@ module biocfd_pcor_vcor
             derr4=dmax1(derr4,var)
  30      CONTINUE
         !$omp end parallel do
-        !$acc end parallel
+        !$acc end parallel loop
         end if
         !$acc parallel loop gang vector collapse(3) default(present) private (i, j, k)
         !$omp parallel do collapse (3) private (i,j,k) num_threads(48)
@@ -330,7 +330,7 @@ module biocfd_pcor_vcor
         END DO
         END DO
         !$omp end parallel do
-        !$acc end parallel
+        !$acc end parallel loop
 
          block(g)%derr2=derr4
          IF (derr4>=epsi .and. block(g)%nIterPcor <= pcItaMax) GOTO 3
@@ -351,7 +351,7 @@ module biocfd_pcor_vcor
        END DO
        END DO
        END DO
-       !$acc end parallel
+       !$acc end parallel loop
         endif
 
       END SUBROUTINE updateVelocity_newv

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -292,7 +292,7 @@ module biocfd_search
            block(g)%cosBeta(n)  = block(g)%cosBeta(n)/lenEl*binor                !direction cosine unit normal along y
            block(g)%cosGamma(n) = block(g)%cosGamma(n)/lenEl*binor               !direction cosine unit normal along z
         ENDDO
-       !$acc end parallel
+       !$acc end parallel loop
 
         print*, 'SurfaceNorm done, inor =', inor
 
@@ -373,7 +373,7 @@ module biocfd_search
          END DO
          END DO
          !$omp end parallel do
-!$acc end parallel
+!$acc end parallel loop
 
 !$acc parallel loop collapse(3) default(present)
            DO k = block(g)%k_startSearch, block(g)%k_endSearch
@@ -391,7 +391,7 @@ module biocfd_search
            END DO
            END DO
            END DO
-!$acc end parallel
+!$acc end parallel loop
 
 
          WRITE(filename1,1) g
@@ -553,7 +553,7 @@ module biocfd_search
          END DO
          END DO
          END DO
-!$acc end parallel
+!$acc end parallel loop
 
 !$acc parallel loop collapse(3) default(present)
            DO k = block(g)%k_startSearch, block(g)%k_endSearch
@@ -572,7 +572,7 @@ module biocfd_search
            END DO
            END DO
            END DO
-!$acc end parallel
+!$acc end parallel loop
 
         block(g)%ibCellCount = 0
          block(g)%solidCellCount = 0
@@ -624,7 +624,7 @@ module biocfd_search
                  END DO
                  END DO
                  END DO
-        !$acc end parallel
+        !$acc end parallel loop
 
         !$acc parallel loop default(present)
         DO n = 1, block(g)%ibCellCount
@@ -635,7 +635,7 @@ module biocfd_search
             block(g)%cell2(i, j, k) = 2
 
          END DO
-        !$acc end parallel
+        !$acc end parallel loop
 
         block(g)%TSCellCount = 0
         tscnt=0
@@ -650,7 +650,7 @@ module biocfd_search
                  END DO
                  END DO
                  END DO
-        !$acc end parallel
+        !$acc end parallel loop
 
         block(g)%TSCellCount = tscnt
         print*, 'TScell count =', block(g)%TSCellCount
@@ -658,7 +658,6 @@ module biocfd_search
         ALLOCATE(block(g)%TSIndexPtr(block(g)%TSCellCount,3))
 
         iPt1 = 0
-        !$acc loop collapse(3) seq
                  DO k = 0, block(g)%nz+3
                  DO j = 0, block(g)%ny+3
                  DO i = 0, block(g)%nx+3
@@ -718,7 +717,7 @@ module biocfd_search
            block(g)%w1_ghost(n)  = 0.
            block(g)%w1t_ghost(n) = 0.
         ENDDO
-        !$acc end parallel
+        !$acc end parallel loop
 
            enddo
              END SUBROUTINE findTScells
@@ -793,7 +792,7 @@ module biocfd_search
            END DO
            END DO
         ENDDO
-!$acc end parallel
+!$acc end parallel loop
 
 !$acc parallel loop gang vector default(present)
         DO nn = 1, block(g)%ibCellCount
@@ -841,7 +840,7 @@ ibcnt=0
          END DO
          END DO
          END DO
-!$acc end parallel
+!$acc end parallel loop
   block(g)%ibCellCount = ibcnt
   block(g)%solidCellCount = sdcnt
 block(g)%fluidCellCount = flcnt
@@ -1050,7 +1049,7 @@ block(g)%fluidCellCount = flcnt
                            (n1y -block(g)% ycent(nel2w2))*block(g)%cosBeta(nel2w2)  + &
                            (n3z -block(g)% zcent(nel2w2))*block(g)%cosGamma(nel2w2)
         END DO
-        !$acc end parallel
+        !$acc end parallel loop
 
         ! DEALLOCATE (block(g)%minElemcell)
          END DO


### PR DESCRIPTION
This should allow `gfortran` to build the code with the openacc directives enabled.

Closes #102.

Todo
- [x] Test that this doesn't affect any of the output when running on Baskerville