### PR TITLE
Add OMP directives to tagging_th loop

### DIFF
--- a/src/Search.f90
+++ b/src/Search.f90
@@ -305,7 +305,7 @@ module biocfd_search
 
         INTEGER(int64) :: g, n, m, i, j, k,  nel2Cen, nel2Pnt, sumNodeId
         REAL(dp)      :: minDis1, minDis, &
-                         n2dotn, cent_x, cent_y, cent_z, dis_cen, dis_pnt
+                         n2dotn, dis_cen, dis_pnt
 
         CHARACTER(LEN=120) :: filename1
         DO g=blk_start, nblocks
@@ -319,7 +319,6 @@ module biocfd_search
 
  !$acc parallel loop collapse(3) default(present)
         !$omp parallel do default(none) private(minDis, minDis1) &
-        !$omp& private(cent_x, cent_y, cent_z) &
         !$omp& private(dis_cen, dis_pnt, nel2Cen, nel2Pnt, n2dotn) &
         !$omp& shared(g, block)
         DO k = block(g)%k_startSearch, block(g)%k_endSearch
@@ -330,19 +329,18 @@ module biocfd_search
 
             !$acc loop seq
             DO m = 1, block(g)%ibElems
-            cent_x = block(g)%xcent(m)
-            cent_y = block(g)%ycent(m)
-            cent_z = block(g)%zcent(m)
             ! I wanted to use associate here, but nvfortran doesn't
             ! like it on the GPU (although I can't find an existing
             ! bug report of this).
             !
             ! No need to take the sqrt because we are just looking for
             ! the minimum distance
-               dis_cen  = (block(g)%xp(i)-cent_x)**2 + (block(g)%yp(j)-cent_y)**2 &
-                        + (block(g)%zp(k)-cent_z)**2
-               dis_pnt  = (block(g)%x1(i)-cent_x)**2 + (block(g)%y1(j)-cent_y)**2 &
-                        + (block(g)%z1(k)-cent_z)**2
+               dis_cen  = (block(g)%xp(i)-block(g)%xcent(m))**2 &
+                        + (block(g)%yp(j)-block(g)%ycent(m))**2 &
+                        + (block(g)%zp(k)-block(g)%zcent(m))**2
+               dis_pnt  = (block(g)%x1(i)-block(g)%xcent(m))**2 &
+                        + (block(g)%y1(j)-block(g)%ycent(m))**2 &
+                        + (block(g)%z1(k)-block(g)%zcent(m))**2
                IF (dis_cen<minDis) THEN
                   minDis    = dis_cen
                   nel2Cen   = m

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -333,8 +333,13 @@ module biocfd_search
             cent_x = block(g)%xcent(m)
             cent_y = block(g)%ycent(m)
             cent_z = block(g)%zcent(m)
-               dis_cen  = dsqrt( (block(g)%yp(j)-cent_y)**2 + (block(g)%xp(i)-cent_x)**2  + (block(g)%zp(k)-cent_z)**2)
-               dis_pnt  = dsqrt( (block(g)%y1(j)-cent_y)**2 + (block(g)%x1(i)-cent_x)**2  + (block(g)%z1(k)-cent_z)**2)
+            ! There is no need to take the sqrt here because we are just comparing distances
+            associate (x => block(g)%xp(i), y => block(g)%yp(j), z => block(g)%zp(k))
+               dis_cen  = (x-cent_x)**2  + (y-cent_y)**2 + (z-cent_z)**2
+            end associate
+            associate (x => block(g)%x1(i), y => block(g)%y1(j), z => block(g)%z1(k))
+               dis_pnt  = (x-cent_x)**2  + (y-cent_y)**2 + (z-cent_z)**2
+            end associate
                IF (dis_cen<minDis) THEN
                   minDis    = dis_cen
                   nel2Cen   = m
@@ -344,6 +349,7 @@ module biocfd_search
                   nel2Pnt   = m
                ENDIF
             ENDDO
+
             IF((block(g)%x1(i)<=block(g)%xcent(nel2Cen) .AND. &
                 block(g)%x1(i+1)>=block(g)%xcent(nel2Cen)).AND. &
                (block(g)%y1(j)<=block(g)%ycent(nel2Cen) .AND. &
@@ -351,7 +357,6 @@ module biocfd_search
                (block(g)%z1(k)<=block(g)%zcent(nel2Cen) .AND. &
                 block(g)%z1(k+1)>=block(g)%zcent(nel2Cen))) THEN
                block(g)%cell(i,j,k) = 2
-
             ENDIF
 
             n2dotn  = (block(g)%x1(i) - block(g)%xcent(nel2Pnt))*block(g)%cosAlpha(nel2Pnt) + &

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -336,9 +336,9 @@ module biocfd_search
             ! I wanted to use associate here, but nvfortran doesn't
             ! like it on the GPU (although I can't find an existing
             ! bug report of this)
-               dis_cen  = (block(g)%yp(j)-cent_y)**2 + (block(g)%xp(i)-cent_x)**2 &
+               dis_cen  = (block(g)%xp(i)-cent_x)**2 + (block(g)%yp(j)-cent_y)**2 &
                         + (block(g)%zp(k)-cent_z)**2
-               dis_pnt  = (block(g)%y1(j)-cent_y)**2 + (block(g)%x1(i)-cent_x)**2 &
+               dis_pnt  = (block(g)%x1(i)-cent_x)**2 + (block(g)%y1(j)-cent_y)**2 &
                         + (block(g)%z1(k)-cent_z)**2
                IF (dis_cen<minDis) THEN
                   minDis    = dis_cen
@@ -379,7 +379,6 @@ module biocfd_search
            DO j = block(g)%j_startSearch, block(g)%j_endSearch
            DO i = block(g)%i_startSearch, block(g)%i_endSearch
                IF (block(g)%cell(i,j,k)/=2) THEN
-                  sumNodeId = 0
                   sumNodeId = block(g)%nodeIdTag(i,j,k)      + block(g)%nodeIdTag(i+1,j,k)     &
                               + block(g)%nodeIdTag(i,j+1,k)    + block(g)%nodeIdTag(i+1,j+1,k)   &
                               + block(g)%nodeIdTag(i,j,k+1)    + block(g)%nodeIdTag(i+1,j,k+1)     &
@@ -408,7 +407,7 @@ module biocfd_search
 
 
 
-        block(g)%ibCellCount = 0
+         block(g)%ibCellCount = 0
          block(g)%solidCellCount = 0
          block(g)%fluidCellCount = 0
          DO k = 2, block(g)%nz+1

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -335,7 +335,10 @@ module biocfd_search
             cent_z = block(g)%zcent(m)
             ! I wanted to use associate here, but nvfortran doesn't
             ! like it on the GPU (although I can't find an existing
-            ! bug report of this)
+            ! bug report of this).
+            !
+            ! No need to take the sqrt because we are just looking for
+            ! the minimum distance
                dis_cen  = (block(g)%xp(i)-cent_x)**2 + (block(g)%yp(j)-cent_y)**2 &
                         + (block(g)%zp(k)-cent_z)**2
                dis_pnt  = (block(g)%x1(i)-cent_x)**2 + (block(g)%y1(j)-cent_y)**2 &

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -304,7 +304,7 @@ module biocfd_search
      SUBROUTINE tagging_th
 
         INTEGER(int64) :: g, n, m, i, j, k,  nel2Cen, nel2Pnt, sumNodeId
-        REAL(dp)      :: n1x, n1y, n1z, n2x, n2y, n2z, minDis1, minDis, &
+        REAL(dp)      :: minDis1, minDis, &
                          n2dotn, cent_x, cent_y, cent_z, dis_cen, dis_pnt
 
         CHARACTER(LEN=120) :: filename1
@@ -318,27 +318,23 @@ module biocfd_search
         n2dotn = 0
 
  !$acc parallel loop collapse(3) default(present)
+        !$omp parallel do default(none) private(minDis, minDis1) &
+        !$omp& private(cent_x, cent_y, cent_z) &
+        !$omp& private(dis_cen, dis_pnt, nel2Cen, nel2Pnt, n2dotn) &
+        !$omp& shared(g, block)
         DO k = block(g)%k_startSearch, block(g)%k_endSearch
         DO j = block(g)%j_startSearch, block(g)%j_endSearch
         DO i = block(g)%i_startSearch, block(g)%i_endSearch
             minDis  = 1e14_dp
             minDis1 = 1e14_dp
 
-            n1x = block(g)%xp(i)
-            n1y = block(g)%yp(j)
-            n1z = block(g)%zp(k)
-
-            n2x = block(g)%x1(i)
-            n2y = block(g)%y1(j)
-            n2z = block(g)%z1(k)
-
             !$acc loop seq
             DO m = 1, block(g)%ibElems
             cent_x = block(g)%xcent(m)
             cent_y = block(g)%ycent(m)
             cent_z = block(g)%zcent(m)
-               dis_cen  = dsqrt( (n1y-cent_y)**2 + (n1x-cent_x)**2  + (n1z-cent_z)**2)
-               dis_pnt  = dsqrt( (n2y-cent_y)**2 + (n2x-cent_x)**2  + (n2z-cent_z)**2)
+               dis_cen  = dsqrt( (block(g)%yp(j)-cent_y)**2 + (block(g)%xp(i)-cent_x)**2  + (block(g)%zp(k)-cent_z)**2)
+               dis_pnt  = dsqrt( (block(g)%y1(j)-cent_y)**2 + (block(g)%x1(i)-cent_x)**2  + (block(g)%z1(k)-cent_z)**2)
                IF (dis_cen<minDis) THEN
                   minDis    = dis_cen
                   nel2Cen   = m
@@ -358,9 +354,9 @@ module biocfd_search
 
             ENDIF
 
-                        n2dotn  = (n2x - block(g)%xcent(nel2Pnt))*block(g)%cosAlpha(nel2Pnt) + &
-                           (n2y - block(g)%ycent(nel2Pnt))*block(g)%cosBeta(nel2Pnt)  + &
-                           (n2z - block(g)%zcent(nel2Pnt))*block(g)%cosGamma(nel2Pnt)
+            n2dotn  = (block(g)%x1(i) - block(g)%xcent(nel2Pnt))*block(g)%cosAlpha(nel2Pnt) + &
+                      (block(g)%y1(j) - block(g)%ycent(nel2Pnt))*block(g)%cosBeta(nel2Pnt)  + &
+                      (block(g)%z1(k) - block(g)%zcent(nel2Pnt))*block(g)%cosGamma(nel2Pnt)
 
             IF (n2dotn>=-1e-16_dp) THEN
                block(g)%nodeIdTag(i,j,k) = 0
@@ -370,6 +366,7 @@ module biocfd_search
          END DO
          END DO
          END DO
+         !$omp end parallel do
 !$acc end parallel
 
 !$acc parallel loop collapse(3) default(present)

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -333,13 +333,13 @@ module biocfd_search
             cent_x = block(g)%xcent(m)
             cent_y = block(g)%ycent(m)
             cent_z = block(g)%zcent(m)
-            ! There is no need to take the sqrt here because we are just comparing distances
-            associate (x => block(g)%xp(i), y => block(g)%yp(j), z => block(g)%zp(k))
-               dis_cen  = (x-cent_x)**2  + (y-cent_y)**2 + (z-cent_z)**2
-            end associate
-            associate (x => block(g)%x1(i), y => block(g)%y1(j), z => block(g)%z1(k))
-               dis_pnt  = (x-cent_x)**2  + (y-cent_y)**2 + (z-cent_z)**2
-            end associate
+            ! I wanted to use associate here, but nvfortran doesn't
+            ! like it on the GPU (although I can't find an existing
+            ! bug report of this)
+               dis_cen  = (block(g)%yp(j)-cent_y)**2 + (block(g)%xp(i)-cent_x)**2 &
+                        + (block(g)%zp(k)-cent_z)**2
+               dis_pnt  = (block(g)%y1(j)-cent_y)**2 + (block(g)%x1(i)-cent_x)**2 &
+                        + (block(g)%z1(k)-cent_z)**2
                IF (dis_cen<minDis) THEN
                   minDis    = dis_cen
                   nel2Cen   = m
@@ -349,7 +349,6 @@ module biocfd_search
                   nel2Pnt   = m
                ENDIF
             ENDDO
-
             IF((block(g)%x1(i)<=block(g)%xcent(nel2Cen) .AND. &
                 block(g)%x1(i+1)>=block(g)%xcent(nel2Cen)).AND. &
                (block(g)%y1(j)<=block(g)%ycent(nel2Cen) .AND. &
@@ -357,6 +356,7 @@ module biocfd_search
                (block(g)%z1(k)<=block(g)%zcent(nel2Cen) .AND. &
                 block(g)%z1(k+1)>=block(g)%zcent(nel2Cen))) THEN
                block(g)%cell(i,j,k) = 2
+
             ENDIF
 
             n2dotn  = (block(g)%x1(i) - block(g)%xcent(nel2Pnt))*block(g)%cosAlpha(nel2Pnt) + &


### PR DESCRIPTION
Essentially a cherry pick of 2d7f5fbfc9bbbee8aa21f5fb64d53f73d6f79c72 from my original attempt of this (#104), but with a little bit of clean up. I attempted to use `associate` to make the code a little cleaner, but `nvfortran` didn't like it in the `openacc` block (worked fine with gfortran on my laptop)

I experimented a bit with adding `collapse(2)` or `collapse(3)` to the loop, but didn't see any noticeable speed difference. Similarly, making the next triple-nested loop after this parallel didn't have a big impact.

This is really only for running locally, OpenACC will still be used for the offloading on supported hardware.

Running one iteration of the standard problem (see #91) takes about 9m15 on a MacBook Pro M1 Pro.