### PR TITLE
First attempt at removing repetition in Forcing.f90

### DIFF
--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -27,6 +27,7 @@ SUBROUTINE pressureForcing1
  !$acc           dpdn_e, k, j, i, il, jl, kl, i_x1, i_y1,               &
  !$acc           i_z1,ac_z,ac_y,ac_x,at_y,at_z,ac_x_al,ac_y_al,at_x_al,at_y_al)         &
  !$acc default(present)  &
+ !$acc private(derivatives) &
  !$acc firstprivate (block(g)%nx, block(g)%ny,block(g)%nz)
       DO n = 1, block(g)%ibCellCount
          IF (block(g)%ibSurfId(block(g)%nelp(n))==50) THEN

--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -2,6 +2,7 @@ module biocfd_forcing
   use, intrinsic :: iso_fortran_env, only: dp => real64
   ! allow(use-all) - TODO: Aim to fix this in the future
   use global
+  use biocfd_interpolation, only : linear_interpolation, bilinear_interpolation
   implicit none
 
   private
@@ -13,11 +14,10 @@ module biocfd_forcing
 SUBROUTINE pressureForcing1
 
       INTEGER :: n, k, j, i, il, jl, kl, i_x1, i_y1, i_z1, g
-      REAL (dp) :: n1, pos1_x, pos1_y, pos1_z, pt1, &
-                         aval, bval, cval, p_pos1, sur2nodeDis, dpdn, p_x1, p_x2, &
-                         p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, &
-                         p_z1_x1, p_z2_x1, p_z1_x2, p_z2_x2, h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e
+      REAL (dp) :: n1, pos1_x, pos1_y, pos1_z, pt1, aval, bval, cval, p_pos1, sur2nodeDis, dpdn, &
+                   dpdn_e
 
+      real(dp) :: derivatives(3)
       dpdn = 0._dp
         DO g=blk_start,nblocks
 
@@ -86,74 +86,13 @@ SUBROUTINE pressureForcing1
             if(pos1_z>=block(g)%zp(kl).and.pos1_z<block(g)%zp(kl+1)) i_z1 = kl
          END DO
 
-         !interpolation along x  @ z1 plane
-         p_x1_z1 = block(g)%p(i_x1, i_y1, i_z1)   + (block(g)%p(i_x1+1, i_y1, i_z1) &
-                   - block(g)%p(i_x1, i_y1, i_z1)) &
-                   * (pos1_x - block(g)%xp(i_x1))/(block(g)%xp(i_x1+1) - block(g)%xp(i_x1))
-         p_x2_z1 = block(g)%p(i_x1, i_y1+1, i_z1) + (block(g)%p(i_x1+1, i_y1+1, i_z1) &
-                   - block(g)%p(i_x1, i_y1+1, i_z1)) &
-                   * (pos1_x - block(g)%xp(i_x1))/(block(g)%xp(i_x1+1) - block(g)%xp(i_x1))
+        call compute_value_and_derivatives(pos1_x, pos1_y, pos1_z, i_x1, i_y1, i_z1, &
+                                           block(g)%xp, block(g)%yp, block(g)%zp, &
+                                           block(g)%p, p_pos1, derivatives)
 
-         !interpolation along x  @ z2 plane
-         p_x1_z2 = block(g)%p(i_x1, i_y1, i_z1+1)   + (block(g)%p(i_x1+1, i_y1, i_z1+1) &
-                   - block(g)%p(i_x1, i_y1, i_z1+1)) &
-                   * (pos1_x - block(g)%xp(i_x1))/(block(g)%xp(i_x1+1) - block(g)%xp(i_x1))
-         p_x2_z2 = block(g)%p(i_x1, i_y1+1, i_z1+1) + (block(g)%p(i_x1+1, i_y1+1, i_z1+1) &
-                   - block(g)%p(i_x1, i_y1+1, i_z1+1)) &
-                   * (pos1_x - block(g)%xp(i_x1))/(block(g)%xp(i_x1+1) - block(g)%xp(i_x1))
-
-         !This will be used for dpdz calculation point 1
-         p_z1 = p_x1_z1 + (p_x2_z1 - p_x1_z1) &
-                * (pos1_y - block(g)%yp(i_y1))/(block(g)%yp(i_y1+1)-block(g)%yp(i_y1))
-         p_z2 = p_x1_z2 + (p_x2_z2 - p_x1_z2) &
-                * (pos1_y - block(g)%yp(i_y1))/(block(g)%yp(i_y1+1)-block(g)%yp(i_y1))
-
-         !This will be used for dpdy calculation at point 1
-         p_y1 = p_x1_z1 + (p_x1_z2 - p_x1_z1) &
-                * (pos1_z - block(g)%zp(i_z1))/(block(g)%zp(i_z1+1)-block(g)%zp(i_z1))
-         p_y2 = p_x2_z1 + (p_x2_z2 - p_x2_z1) &
-                * (pos1_z - block(g)%zp(i_z1))/(block(g)%zp(i_z1+1)-block(g)%zp(i_z1))
-
-         !interpolation along z @ x1 plane
-         p_z1_x1 = block(g)%p(i_x1, i_y1, i_z1) + (block(g)%p(i_x1, i_y1, i_z1+1) &
-                   - block(g)%p(i_x1, i_y1, i_z1)) &
-                   * (pos1_z - block(g)%zp(i_z1))/(block(g)%zp(i_z1+1) - block(g)%zp(i_z1))
-         p_z2_x1 = block(g)%p(i_x1, i_y1+1, i_z1) + (block(g)%p(i_x1, i_y1+1, i_z1+1) &
-                   - block(g)%p(i_x1, i_y1+1, i_z1)) &
-                   * (pos1_z - block(g)%zp(i_z1))/(block(g)%zp(i_z1+1) - block(g)%zp(i_z1))
-
-         !interpolation along z @ x2 plane
-         p_z1_x2 = block(g)%p(i_x1+1, i_y1, i_z1) + (block(g)%p(i_x1+1, i_y1, i_z1+1) &
-                   - block(g)%p(i_x1+1, i_y1, i_z1)) &
-                   * (pos1_z - block(g)%zp(i_z1))/(block(g)%zp(i_z1+1) - block(g)%zp(i_z1))
-         p_z2_x2 = block(g)%p(i_x1+1, i_y1+1, i_z1) + (block(g)%p(i_x1+1, i_y1+1, i_z1+1) &
-                   - block(g)%p(i_x1+1, i_y1+1, i_z1)) &
-                   * (pos1_z - block(g)%zp(i_z1))/(block(g)%zp(i_z1+1) - block(g)%zp(i_z1))
-
-         !This will be used for dpdx calculation at point 1
-         p_x1 = p_z1_x1 + (p_z2_x1 - p_z1_x1) &
-                * (pos1_y - block(g)%yp(i_y1))/(block(g)%yp(i_y1+1)-block(g)%yp(i_y1))
-         p_x2 = p_z1_x2 + (p_z2_x2 - p_z1_x2) &
-                * (pos1_y - block(g)%yp(i_y1))/(block(g)%yp(i_y1+1)-block(g)%yp(i_y1))
-
-         p_pos1 = p_x1 + (p_x2 - p_x1) &
-                  * (pos1_x - block(g)%xp(i_x1))/(block(g)%xp(i_x1+1)-block(g)%xp(i_x1))
-
-         h2 = dabs(block(g)%xp(i_x1+1) - pos1_x)
-         h1 = dabs(block(g)%xp(i_x1)   - pos1_x)
-         dpdx_e = (h1**2*p_x2 - h2**2*p_x1 + (h2**2- h1**2)*p_pos1)/(h1*h2*(h1+h2)+1e-16_dp)
-
-         h2 = dabs(block(g)%yp(i_y1+1) - pos1_y)
-         h1 = dabs(block(g)%yp(i_y1)   - pos1_y)
-         dpdy_e = (h1**2*p_y2 - h2**2*p_y1 + (h2**2- h1**2)*p_pos1)/(h1*h2*(h1+h2)+1e-16_dp)
-
-         h2 = dabs(block(g)%zp(i_z1+1) - pos1_z)
-         h1 = dabs(block(g)%zp(i_z1)   - pos1_z)
-         dpdz_e = (h1**2*p_z2 - h2**2*p_z1 + (h2**2- h1**2)*p_pos1)/(h1*h2*(h1+h2)+1e-16_dp)
-
-         dpdn_e = dpdx_e*block(g)%cosAlpha(block(g)%nelp(n)) &
-                  + dpdy_e*block(g)%cosBeta(block(g)%nelp(n)) &
-                  + dpdz_e*block(g)%cosGamma(block(g)%nelp(n))
+        dpdn_e = derivatives(1) * block(g)%cosAlpha(block(g)%nelp(n)) &
+               + derivatives(2) * block(g)%cosBeta(block(g)%nelp(n)) &
+               + derivatives(3) * block(g)%cosGamma(block(g)%nelp(n))
 
          n1 = pt1 + sur2nodeDis
 
@@ -2625,4 +2564,70 @@ SUBROUTINE velocityForcingField
       ENDDO
 
 END SUBROUTINE velocityForcingField
+
+pure function compute_derivative(x, x2, x1, p_x, p_x2, p_x1) result(out)
+  real(dp), intent(in) :: x, x2, x1, p_x, p_x2, p_x1
+  real(dp) :: out
+
+  real(dp) :: h1, h2
+
+  h2 = abs(x2 - x)
+  h1 = abs(x1 - x)
+  out = (h1**2*p_x2 - h2**2*p_x1 + (h2**2- h1**2)*p_x)/(h1*h2*(h1+h2)+1e-16_dp)
+end function compute_derivative
+
+pure function multi_bilinear_interpolation(x, y, z, i, j, k, xgrid, ygrid, zgrid, var) result(out)
+  real(dp), intent(in) :: x, y, z
+  integer, intent(in) :: i, j, k
+  real(dp), intent(in), dimension(:) :: xgrid, ygrid, zgrid
+  real(dp), intent(in), dimension(:, :, :) :: var
+  !> The out is [[x1, x2], [y1, y2], [z1, z1]]
+  real(dp) :: out(3, 2)
+
+  ! p_x1 y -- z plane
+  out(1, 1) = bilinear_interpolation(y, z, ygrid(j+1), ygrid(j), zgrid(k+1), zgrid(k), &
+                        [var(i, j, k), var(i, j+1, k), var(i, j, k+1), var(i, j+1, k+1)])
+  ! p_x2 y -- z plane
+  out(1, 2) = bilinear_interpolation(y, z, ygrid(j+1), ygrid(j), zgrid(k+1), zgrid(k), &
+                        [var(i+1, j, k), var(i+1, j+1, k), var(i+1, j, k+1), var(i+1, j+1, k+1)])
+
+  ! p_y1 x -- z plane
+  out(2, 1) = bilinear_interpolation(x, z, xgrid(i+1), xgrid(i), zgrid(k+1), zgrid(k), &
+                        [var(i, j, k), var(i+1, j, k), var(i, j, k+1), var(i+1, j, k+1)])
+  ! p_y2 x -- z plane
+  out(2, 2) = bilinear_interpolation(x, z, xgrid(i+1), xgrid(i), zgrid(k+1), zgrid(k), &
+                        [var(i, j+1, k), var(i+1, j+1, k), var(i, j+1, k+1), var(i+1, j+1, k+1)])
+
+  ! p_z1 x -- y plane
+  out(3, 1) = bilinear_interpolation(x, y, xgrid(i+1), xgrid(i), ygrid(j+1), ygrid(j), &
+                        [var(i, j, k), var(i+1, j, k), var(i, j+1, k), var(i+1, j+1, k)])
+  ! p_z2 x -- y plane
+  out(3, 2) = bilinear_interpolation(x, y, xgrid(i+1), xgrid(i), ygrid(j+1), ygrid(j), &
+                        [var(i, j, k+1), var(i+1, j, k+1), var(i, j+1, k+1), var(i+1, j+1, k+1)])
+
+end function multi_bilinear_interpolation
+
+subroutine compute_value_and_derivatives(x, y, z, i, j, k, xgrid, ygrid, zgrid, var, &
+                                         val, derivatives)
+  real(dp), intent(in) :: x, y, z
+  integer, intent(in) :: i, j, k
+  real(dp), intent(in), dimension(:) :: xgrid, ygrid, zgrid
+  real(dp), intent(in), dimension(:, :, :) :: var
+
+  real(dp), intent(out) :: val
+  real(dp), intent(out) :: derivatives(3)
+
+  ! Internal variables
+  ! tmp to hold interpolated results, [[x1, x2], [y1, y2], [z1, z1]]
+  real (dp) :: tmp(3, 2)
+
+  tmp = multi_bilinear_interpolation(x, y, z, i, j, k, xgrid, ygrid, zgrid, var)
+  val = linear_interpolation(x, xgrid(i+1), xgrid(i), tmp(1, 2), tmp(1, 1))
+
+  derivatives(1) = compute_derivative(x, xgrid(i+1), xgrid(i), val, tmp(1, 2), tmp(1, 1))
+  derivatives(2) = compute_derivative(y, ygrid(j+1), ygrid(j), val, tmp(2, 2), tmp(2, 1))
+  derivatives(3) = compute_derivative(z, zgrid(k+1), zgrid(k), val, tmp(3, 2), tmp(3, 1))
+
+end subroutine compute_value_and_derivatives
+
 end module biocfd_forcing

--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -2575,10 +2575,22 @@ pure function compute_derivative(x, x2, x1, p_x, p_x2, p_x1) result(out)
   out = (h1**2*p_x2 - h2**2*p_x1 + (h2**2- h1**2)*p_x)/(h1*h2*(h1+h2)+1e-16_dp)
 end function compute_derivative
 
+!> Compute bilinear interpolation on six faces of a cuboid.
+!>
+!> Given the eight corners of a cuboid find the interpolated values on
+!> the faces of the cuboid at some target position e.g. if the corners
+!> are at [(x1,y1,z1), (x2,y1,z1), (x1,y2,z1), (x2,y2,z1), (x1,y1,z2),
+!> (x2,y1,z2), (x1,y2,z2), (x2,y2,z2)], and the target position is (x,
+!> y, z), returns the interpolated values of something at [(x,y,z1),
+!> (x,y,z2), (x,y1,z), (x,y2,z), (x1,y,z), (x2,y,z)].
 pure function multi_bilinear_interpolation(x, y, z, i, j, k, xgrid, ygrid, zgrid, var) result(out)
+  !> The target position for the interpolation
   real(dp), intent(in) :: x, y, z
+  !> The indices of the corners of the cuboid on the grid
   integer, intent(in) :: i, j, k
+  !> The grids determining the positions of the corners of the cuboid
   real(dp), intent(in), dimension(:) :: xgrid, ygrid, zgrid
+  !> The variable to be interpolated
   real(dp), intent(in), dimension(:, :, :) :: var
   !> The out is [[x1, x2], [y1, y2], [z1, z1]]
   real(dp) :: out(3, 2)

--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -2604,27 +2604,27 @@ subroutine compute_value_and_derivatives(x, y, z, i, j, k, xgrid, ygrid, zgrid, 
   ! hand" inlined here
   !
   ! p_x1 y -- z plane
-  tmp(1, 1) = bilinear_interpolation(y, z, ygrid(j+1), ygrid(j), zgrid(k+1), zgrid(k), &
+  tmp(1, 1) = bilinear_interpolation(y, z, ygrid(j), ygrid(j+1), zgrid(k), zgrid(k+1), &
                         [var(i, j, k), var(i, j+1, k), var(i, j, k+1), var(i, j+1, k+1)])
   ! p_x2 y -- z plane
-  tmp(1, 2) = bilinear_interpolation(y, z, ygrid(j+1), ygrid(j), zgrid(k+1), zgrid(k), &
+  tmp(1, 2) = bilinear_interpolation(y, z, ygrid(j), ygrid(j+1), zgrid(k), zgrid(k+1), &
                         [var(i+1, j, k), var(i+1, j+1, k), var(i+1, j, k+1), var(i+1, j+1, k+1)])
 
   ! p_y1 x -- z plane
-  tmp(2, 1) = bilinear_interpolation(x, z, xgrid(i+1), xgrid(i), zgrid(k+1), zgrid(k), &
+  tmp(2, 1) = bilinear_interpolation(x, z, xgrid(i), xgrid(i+1), zgrid(k), zgrid(k+1), &
                         [var(i, j, k), var(i+1, j, k), var(i, j, k+1), var(i+1, j, k+1)])
   ! p_y2 x -- z plane
-  tmp(2, 2) = bilinear_interpolation(x, z, xgrid(i+1), xgrid(i), zgrid(k+1), zgrid(k), &
+  tmp(2, 2) = bilinear_interpolation(x, z, xgrid(i), xgrid(i+1), zgrid(k), zgrid(k+1), &
                         [var(i, j+1, k), var(i+1, j+1, k), var(i, j+1, k+1), var(i+1, j+1, k+1)])
 
   ! p_z1 x -- y plane
-  tmp(3, 1) = bilinear_interpolation(x, y, xgrid(i+1), xgrid(i), ygrid(j+1), ygrid(j), &
+  tmp(3, 1) = bilinear_interpolation(x, y, xgrid(i), xgrid(i+1), ygrid(j), ygrid(j+1), &
                         [var(i, j, k), var(i+1, j, k), var(i, j+1, k), var(i+1, j+1, k)])
   ! p_z2 x -- y plane
-  tmp(3, 2) = bilinear_interpolation(x, y, xgrid(i+1), xgrid(i), ygrid(j+1), ygrid(j), &
+  tmp(3, 2) = bilinear_interpolation(x, y, xgrid(i), xgrid(i+1), ygrid(j), ygrid(j+1), &
                         [var(i, j, k+1), var(i+1, j, k+1), var(i, j+1, k+1), var(i+1, j+1, k+1)])
 
-  val = linear_interpolation(x, xgrid(i+1), xgrid(i), tmp(1, 2), tmp(1, 1))
+  val = linear_interpolation(x, xgrid(i), xgrid(i+1), tmp(1, 1), tmp(1, 2))
 
   derivatives(1) = compute_derivative(x, xgrid(i+1), xgrid(i), val, tmp(1, 2), tmp(1, 1))
   derivatives(2) = compute_derivative(y, ygrid(j+1), ygrid(j), val, tmp(2, 2), tmp(2, 1))

--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -24,8 +24,7 @@ SUBROUTINE pressureForcing1
 
  !$acc parallel loop gang vector                                                                                          &
  !$acc private (n, n1, pos1_x, pos1_y, pos1_z, pt1, aval, bval, cval, p_pos1, sur2nodeDis, dpdn,                   &
- !$acc           p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1,                &
- !$acc           p_z1_x2, p_z2_x2, h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, k, j, i, il, jl, kl, i_x1, i_y1,               &
+ !$acc           dpdn_e, k, j, i, il, jl, kl, i_x1, i_y1,               &
  !$acc           i_z1,ac_z,ac_y,ac_x,at_y,at_z,ac_x_al,ac_y_al,at_x_al,at_y_al)         &
  !$acc default(present)  &
  !$acc firstprivate (block(g)%nx, block(g)%ny,block(g)%nz)

--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -2,7 +2,7 @@ module biocfd_forcing
   use, intrinsic :: iso_fortran_env, only: dp => real64
   ! allow(use-all) - TODO: Aim to fix this in the future
   use global
-  use biocfd_interpolation, only : linear_interpolation, bilinear_interpolation
+  use biocfd_interpolation, only: linear_interpolation, bilinear_interpolation
   implicit none
 
   private
@@ -2576,49 +2576,6 @@ pure function compute_derivative(x, x2, x1, p_x, p_x2, p_x1) result(out)
   out = (h1**2*p_x2 - h2**2*p_x1 + (h2**2- h1**2)*p_x)/(h1*h2*(h1+h2)+1e-16_dp)
 end function compute_derivative
 
-!> Compute bilinear interpolation on six faces of a cuboid.
-!>
-!> Given the eight corners of a cuboid find the interpolated values on
-!> the faces of the cuboid at some target position e.g. if the corners
-!> are at [(x1,y1,z1), (x2,y1,z1), (x1,y2,z1), (x2,y2,z1), (x1,y1,z2),
-!> (x2,y1,z2), (x1,y2,z2), (x2,y2,z2)], and the target position is (x,
-!> y, z), returns the interpolated values of something at [(x,y,z1),
-!> (x,y,z2), (x,y1,z), (x,y2,z), (x1,y,z), (x2,y,z)].
-pure function multi_bilinear_interpolation(x, y, z, i, j, k, xgrid, ygrid, zgrid, var) result(out)
-  !> The target position for the interpolation
-  real(dp), intent(in) :: x, y, z
-  !> The indices of the corners of the cuboid on the grid
-  integer, intent(in) :: i, j, k
-  !> The grids determining the positions of the corners of the cuboid
-  real(dp), intent(in), dimension(:) :: xgrid, ygrid, zgrid
-  !> The variable to be interpolated
-  real(dp), intent(in), dimension(:, :, :) :: var
-  !> The out is [[x1, x2], [y1, y2], [z1, z1]]
-  real(dp) :: out(3, 2)
-
-  ! p_x1 y -- z plane
-  out(1, 1) = bilinear_interpolation(y, z, ygrid(j+1), ygrid(j), zgrid(k+1), zgrid(k), &
-                        [var(i, j, k), var(i, j+1, k), var(i, j, k+1), var(i, j+1, k+1)])
-  ! p_x2 y -- z plane
-  out(1, 2) = bilinear_interpolation(y, z, ygrid(j+1), ygrid(j), zgrid(k+1), zgrid(k), &
-                        [var(i+1, j, k), var(i+1, j+1, k), var(i+1, j, k+1), var(i+1, j+1, k+1)])
-
-  ! p_y1 x -- z plane
-  out(2, 1) = bilinear_interpolation(x, z, xgrid(i+1), xgrid(i), zgrid(k+1), zgrid(k), &
-                        [var(i, j, k), var(i+1, j, k), var(i, j, k+1), var(i+1, j, k+1)])
-  ! p_y2 x -- z plane
-  out(2, 2) = bilinear_interpolation(x, z, xgrid(i+1), xgrid(i), zgrid(k+1), zgrid(k), &
-                        [var(i, j+1, k), var(i+1, j+1, k), var(i, j+1, k+1), var(i+1, j+1, k+1)])
-
-  ! p_z1 x -- y plane
-  out(3, 1) = bilinear_interpolation(x, y, xgrid(i+1), xgrid(i), ygrid(j+1), ygrid(j), &
-                        [var(i, j, k), var(i+1, j, k), var(i, j+1, k), var(i+1, j+1, k)])
-  ! p_z2 x -- y plane
-  out(3, 2) = bilinear_interpolation(x, y, xgrid(i+1), xgrid(i), ygrid(j+1), ygrid(j), &
-                        [var(i, j, k+1), var(i+1, j, k+1), var(i, j+1, k+1), var(i+1, j+1, k+1)])
-
-end function multi_bilinear_interpolation
-
 subroutine compute_value_and_derivatives(x, y, z, i, j, k, xgrid, ygrid, zgrid, var, &
                                          val, derivatives)
   real(dp), intent(in) :: x, y, z
@@ -2633,7 +2590,40 @@ subroutine compute_value_and_derivatives(x, y, z, i, j, k, xgrid, ygrid, zgrid, 
   ! tmp to hold interpolated results, [[x1, x2], [y1, y2], [z1, z1]]
   real (dp) :: tmp(3, 2)
 
-  tmp = multi_bilinear_interpolation(x, y, z, i, j, k, xgrid, ygrid, zgrid, var)
+  ! Compute bilinear interpolation on six faces of a cuboid.
+  !
+  ! Given the eight corners of a cuboid find the interpolated values on
+  ! the faces of the cuboid at some target position e.g. if the corners
+  ! are at [(x1,y1,z1), (x2,y1,z1), (x1,y2,z1), (x2,y2,z1), (x1,y1,z2),
+  ! (x2,y1,z2), (x1,y2,z2), (x2,y2,z2)], and the target position is (x,
+  ! y, z), returns the interpolated values of something at [(x,y,z1),
+  ! (x,y,z2), (x,y1,z), (x,y2,z), (x1,y,z), (x2,y,z)].
+  !
+  ! Note: the multi bilinear interpolation was originally in its own
+  ! function, but nvfortran had problems inlining it so it is "by
+  ! hand" inlined here
+  !
+  ! p_x1 y -- z plane
+  tmp(1, 1) = bilinear_interpolation(y, z, ygrid(j+1), ygrid(j), zgrid(k+1), zgrid(k), &
+                        [var(i, j, k), var(i, j+1, k), var(i, j, k+1), var(i, j+1, k+1)])
+  ! p_x2 y -- z plane
+  tmp(1, 2) = bilinear_interpolation(y, z, ygrid(j+1), ygrid(j), zgrid(k+1), zgrid(k), &
+                        [var(i+1, j, k), var(i+1, j+1, k), var(i+1, j, k+1), var(i+1, j+1, k+1)])
+
+  ! p_y1 x -- z plane
+  tmp(2, 1) = bilinear_interpolation(x, z, xgrid(i+1), xgrid(i), zgrid(k+1), zgrid(k), &
+                        [var(i, j, k), var(i+1, j, k), var(i, j, k+1), var(i+1, j, k+1)])
+  ! p_y2 x -- z plane
+  tmp(2, 2) = bilinear_interpolation(x, z, xgrid(i+1), xgrid(i), zgrid(k+1), zgrid(k), &
+                        [var(i, j+1, k), var(i+1, j+1, k), var(i, j+1, k+1), var(i+1, j+1, k+1)])
+
+  ! p_z1 x -- y plane
+  tmp(3, 1) = bilinear_interpolation(x, y, xgrid(i+1), xgrid(i), ygrid(j+1), ygrid(j), &
+                        [var(i, j, k), var(i+1, j, k), var(i, j+1, k), var(i+1, j+1, k)])
+  ! p_z2 x -- y plane
+  tmp(3, 2) = bilinear_interpolation(x, y, xgrid(i+1), xgrid(i), ygrid(j+1), ygrid(j), &
+                        [var(i, j, k+1), var(i+1, j, k+1), var(i, j+1, k+1), var(i+1, j+1, k+1)])
+
   val = linear_interpolation(x, xgrid(i+1), xgrid(i), tmp(1, 2), tmp(1, 1))
 
   derivatives(1) = compute_derivative(x, xgrid(i+1), xgrid(i), val, tmp(1, 2), tmp(1, 1))

--- a/src/Interpolation.f90
+++ b/src/Interpolation.f90
@@ -8,9 +8,13 @@ module biocfd_interpolation
 
         contains
 
+        ! acc routine directives are needed in the following functions
+        ! to ensure that device versions are created
+
         !> Perform linear interpolation between two points
         !> See https://en.wikipedia.org/wiki/Linear_interpolation
         pure function linear_interpolation(x, x1, x0, y1, y0) result(y)
+                !$acc routine
                 real(dp), intent(in) :: x, x1, x0, y1, y0
                 real(dp) :: y
 
@@ -21,6 +25,7 @@ module biocfd_interpolation
         !> Perform bilinear interpolation
         !> See https://en.wikipedia.org/wiki/Bilinear_interpolation
         pure function bilinear_interpolation(x, y, x2, x1, y2, y1, fvals) result(fout)
+                !$acc routine
                 real(dp), intent(in) :: x, y, x2, x1, y2, y1
                 !> The values at [(x1, y1), (x2, y1), (x1, y2), (x2, y2)]
                 real(dp), intent(in) :: fvals(4)

--- a/src/Interpolation.f90
+++ b/src/Interpolation.f90
@@ -13,9 +13,9 @@ module biocfd_interpolation
 
         !> Perform linear interpolation between two points
         !> See https://en.wikipedia.org/wiki/Linear_interpolation
-        pure function linear_interpolation(x, x1, x0, y1, y0) result(y)
+        pure function linear_interpolation(x, x0, x1, y0, y1) result(y)
                 !$acc routine
-                real(dp), intent(in) :: x, x1, x0, y1, y0
+                real(dp), intent(in) :: x, x0, x1, y0, y1
                 real(dp) :: y
 
                 y = y0 + (x - x0) * (y1 - y0) / (x1 - x0)
@@ -24,9 +24,9 @@ module biocfd_interpolation
 
         !> Perform bilinear interpolation
         !> See https://en.wikipedia.org/wiki/Bilinear_interpolation
-        pure function bilinear_interpolation(x, y, x2, x1, y2, y1, fvals) result(fout)
+        pure function bilinear_interpolation(x, y, x1, x2, y1, y2, fvals) result(fout)
                 !$acc routine
-                real(dp), intent(in) :: x, y, x2, x1, y2, y1
+                real(dp), intent(in) :: x, y, x1, x2, y1, y2
                 !> The values at [(x1, y1), (x2, y1), (x1, y2), (x2, y2)]
                 real(dp), intent(in) :: fvals(4)
                 real(dp) :: fout

--- a/src/Interpolation.f90
+++ b/src/Interpolation.f90
@@ -8,57 +8,6 @@ module biocfd_interpolation
 
         contains
 
-        SUBROUTINE billinearInterp(bl_intp_valx,bl_intp_valy,bl_intp_x1,bl_intp_x2,bl_intp_y1, &
-                           bl_intp_y2,bl_intp_f1,bl_intp_f2,bl_intp_f3,bl_intp_f4, &
-                           bl_interp_ans)
-
-        REAL (dp), INTENT(IN) :: bl_intp_valx, bl_intp_valy, bl_intp_x1, bl_intp_x2, &
-                                 bl_intp_y1, bl_intp_y2, &
-                                 bl_intp_f1, bl_intp_f2, bl_intp_f3, bl_intp_f4
-        REAL (dp) :: bl_intp_deno, bl_intp_num, bl_intp_xtx, bl_intp_xxo, bl_intp_yty, &
-                     bl_intp_yyo, bl_intp_first_term, bl_intp_second_term
-        REAL (dp), INTENT(OUT) :: bl_interp_ans
-        bl_intp_deno= (bl_intp_x2-bl_intp_x1) * (bl_intp_y2-bl_intp_y1)
-        bl_intp_xtx= (bl_intp_x2 -bl_intp_valx)
-        bl_intp_xxo=(bl_intp_valx-bl_intp_x1)
-        bl_intp_yty=(bl_intp_y2-bl_intp_valy)
-        bl_intp_yyo=(bl_intp_valy-bl_intp_y1)
-        bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-        bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-        bl_intp_num= bl_intp_first_term + bl_intp_second_term
-
-        bl_interp_ans=(bl_intp_num/bl_intp_deno)
-
-
-        end subroutine billinearInterp
-
-
-        SUBROUTINE distancePts(d_fine_x1, d_fine_y1, d_coarse_x1, d_coarse_y1, d_val_x1, d_val_y1, &
-                               d_fine_frac, d_coarse_frac)
-
-
-        REAL (dp), INTENT(IN) :: d_fine_x1, d_fine_y1, d_coarse_x1,d_coarse_y1, d_val_x1, d_val_y1
-        REAL (dp), INTENT(OUT) :: d_fine_frac,d_coarse_frac
-        REAL (dp) :: tot_d, fine_d
-
-        tot_d=SQRT((d_fine_x1-d_coarse_x1)**2 +(d_fine_y1-d_coarse_y1)**2)
-        fine_d=SQRT((d_fine_x1-d_val_x1)**2 +(d_fine_y1-d_val_y1)**2)
-        d_coarse_frac=fine_d/tot_d
-        d_fine_frac=1-d_fine_frac
-
-        end subroutine distancePts
-
-        SUBROUTINE linearInterp(l_intp_valx, l_intp_x1,l_intp_x2, l_intp_y1, l_intp_y2, l_intp_valy)
-
-        REAL (dp) :: varr
-        REAL (dp), INTENT(IN) :: l_intp_valx, l_intp_x1, l_intp_x2, l_intp_y1, l_intp_y2
-        REAL (dp), INTENT(OUT) :: l_intp_valy
-        varr=0.
-        varr=(l_intp_valx-l_intp_x1)/(l_intp_x2-l_intp_x1)
-        l_intp_valy=(l_intp_y1*(1._dp-varr))+(l_intp_y2*varr)
-
-        end subroutine linearInterp
-
         !> Perform linear interpolation between two points
         !> See https://en.wikipedia.org/wiki/Linear_interpolation
         pure function linear_interpolation(x, x1, x0, y1, y0) result(y)

--- a/src/Interpolation.f90
+++ b/src/Interpolation.f90
@@ -1,6 +1,9 @@
 module biocfd_interpolation
         use, intrinsic :: iso_fortran_env, only: dp => real64, int64
         implicit none
+
+        public :: linear_interpolation, bilinear_interpolation
+
         private
 
         contains
@@ -55,5 +58,32 @@ module biocfd_interpolation
         l_intp_valy=(l_intp_y1*(1._dp-varr))+(l_intp_y2*varr)
 
         end subroutine linearInterp
+
+        !> Perform linear interpolation between two points
+        !> See https://en.wikipedia.org/wiki/Linear_interpolation
+        pure function linear_interpolation(x, x1, x0, y1, y0) result(y)
+                real(dp), intent(in) :: x, x1, x0, y1, y0
+                real(dp) :: y
+
+                y = y0 + (x - x0) * (y1 - y0) / (x1 - x0)
+        end function linear_interpolation
+
+
+        !> Perform bilinear interpolation
+        !> See https://en.wikipedia.org/wiki/Bilinear_interpolation
+        pure function bilinear_interpolation(x, y, x2, x1, y2, y1, fvals) result(fout)
+                real(dp), intent(in) :: x, y, x2, x1, y2, y1
+                !> The values at [(x1, y1), (x2, y1), (x1, y2), (x2, y2)]
+                real(dp), intent(in) :: fvals(4)
+                real(dp) :: fout
+
+                real(dp) :: tmp(2, 1), tmp_fout(1, 1), denom
+
+                tmp = matmul(reshape(fvals, [2, 2]), reshape([y2 - y, y - y1], [2, 1]))
+                denom = (x2 - x1) * (y2 - y1)
+
+                tmp_fout = (matmul(reshape([x2 - x, x - x1], [1, 2]), tmp) / denom)
+                fout = tmp_fout(1, 1)
+        end function bilinear_interpolation
 
 end module biocfd_interpolation

--- a/src/Interpolation.f90
+++ b/src/Interpolation.f90
@@ -31,13 +31,14 @@ module biocfd_interpolation
                 real(dp), intent(in) :: fvals(4)
                 real(dp) :: fout
 
-                real(dp) :: tmp(2, 1), tmp_fout(1, 1), denom
+                real(dp) :: numer, denom
 
-                tmp = matmul(reshape(fvals, [2, 2]), reshape([y2 - y, y - y1], [2, 1]))
+                numer = fvals(1) * (x2 - x) * (y2 - y) + fvals(3) * (x2 - x) * (y - y1) &
+                      + fvals(2) * (x - x1) * (y2 - y) + fvals(4) * (x - x1) * (y - y1)
+
                 denom = (x2 - x1) * (y2 - y1)
 
-                tmp_fout = (matmul(reshape([x2 - x, x - x1], [1, 2]), tmp) / denom)
-                fout = tmp_fout(1, 1)
+                fout = numer / denom
         end function bilinear_interpolation
 
 end module biocfd_interpolation

--- a/test/main.f90
+++ b/test/main.f90
@@ -1,12 +1,24 @@
 program tester
   use, intrinsic :: iso_fortran_env, only : error_unit
-  use testdrive, only : run_testsuite
+  use testdrive, only : run_testsuite, new_testsuite, testsuite_type
   use test_search, only : collect_search
+  use test_interpolation, only: collect_interpolation
   implicit none
-  integer :: stat
+  integer :: stat, is
+  type(testsuite_type), allocatable :: testsuites(:)
+  character(len=*), parameter :: fmt = '("#", *(1x, a))'
 
   stat = 0
-  call run_testsuite(collect_search, error_unit, stat)
+
+  testsuites = [ &
+    new_testsuite("search", collect_search), &
+    new_testsuite("interpolation", collect_interpolation) &
+    ]
+
+  do is = 1, size(testsuites)
+    write(error_unit, fmt) "Testing:", testsuites(is)%name
+    call run_testsuite(testsuites(is)%collect, error_unit, stat)
+  end do
 
   if (stat > 0) then
     write(error_unit, '(i0, 1x, a)') stat, "test(s) failed!"

--- a/test/test_interpolation.f90
+++ b/test/test_interpolation.f90
@@ -1,0 +1,68 @@
+module test_interpolation
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use testdrive, only : error_type, unittest_type, new_unittest, check
+  implicit none
+  private
+
+  public :: collect_interpolation
+
+contains
+
+  !> Collect all exported unit tests
+  subroutine collect_interpolation(testsuite)
+    !> Collection of tests
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+    testsuite = [new_unittest("linear_interpolation", test_linear_interpolation), &
+                 new_unittest("bilinear_interpolation", test_bilinear_interpolation)]
+  end subroutine collect_interpolation
+
+  subroutine test_linear_interpolation(error)
+    use biocfd_interpolation, only: linear_interpolation
+    ! Error handling
+    type(error_type), allocatable, intent(out) :: error
+    real(dp) :: result
+
+    result = linear_interpolation(1.5_dp, 2._dp, 1._dp, 2._dp, 1._dp)
+    call check(error, result, 1.5_dp)
+    if (allocated(error)) return
+
+    ! Actually extrapolation
+    result = linear_interpolation(3._dp, 2._dp, 1._dp, 2._dp, 1._dp)
+    call check(error, result, 3._dp)
+    if (allocated(error)) return
+
+    ! Flat distribution
+    result = linear_interpolation(50._dp, 100._dp, 1._dp, 1._dp, 1._dp)
+    call check(error, result, 1._dp)
+    if (allocated(error)) return
+
+    ! Negative slope
+    result = linear_interpolation(0.5_dp, 1._dp, 0._dp, 0._dp, 10._dp)
+    call check(error, result, 5._dp)
+    if (allocated(error)) return
+
+  end subroutine test_linear_interpolation
+
+
+  subroutine test_bilinear_interpolation(error)
+    use biocfd_interpolation, only: bilinear_interpolation
+    ! Error handling
+    type(error_type), allocatable, intent(out) :: error
+    real(dp) :: result
+
+    ! Flat distribution
+    result = bilinear_interpolation(0.5_dp, 0.5_dp, 1._dp, 0._dp, 1._dp, 0._dp, &
+                                    [1._dp, 1._dp, 1._dp, 1._dp])
+    call check(error, result, 1._dp)
+    if (allocated(error)) return
+
+     ! Actually extrapolation
+    result = bilinear_interpolation(2._dp, 0.5_dp, 1._dp, 0._dp, 1._dp, 0._dp, &
+                                    [1._dp, 2._dp, 3._dp, 4._dp])
+    call check(error, result, 4._dp)
+    if (allocated(error)) return
+
+  end subroutine test_bilinear_interpolation
+
+end module test_interpolation

--- a/test/test_interpolation.f90
+++ b/test/test_interpolation.f90
@@ -52,13 +52,13 @@ contains
     real(dp) :: result
 
     ! Flat distribution
-    result = bilinear_interpolation(0.5_dp, 0.5_dp, 1._dp, 0._dp, 1._dp, 0._dp, &
+    result = bilinear_interpolation(0.5_dp, 0.5_dp, 0._dp, 1._dp, 0._dp, 1._dp, &
                                     [1._dp, 1._dp, 1._dp, 1._dp])
     call check(error, result, 1._dp)
     if (allocated(error)) return
 
      ! Actually extrapolation
-    result = bilinear_interpolation(2._dp, 0.5_dp, 1._dp, 0._dp, 1._dp, 0._dp, &
+    result = bilinear_interpolation(2._dp, 0.5_dp, 0._dp, 1._dp, 0._dp, 1._dp, &
                                     [1._dp, 2._dp, 3._dp, 4._dp])
     call check(error, result, 4._dp)
     if (allocated(error)) return


### PR DESCRIPTION
- Old (unused) interpolation functions in Interpolation.f90 replaced with new ones, following wikipedia notation
- New (private) methods added to Forcing.f90 to perform calculation of interpolated value and derivatives (these use the new interpolation functions)
- Use new `compute_value_and_derivatives` subroutine in `pressureForcing1`

Although this only neatens up `pressureForcing1`, the same changes will be applicable to `velocityForcing1`, `pressureForcingGhost`, `velocityForcingGhost`, `pressureForcingField`, and `velocityForcingField`. I'd propose we update these methods in a future PR so this one can focus on the new functionality. 

There is further repetition that can be targeted in this module but this seems like a good starting point.

#### Todo
- [x] Check performance not degraded - no major change for a single iteration
- [x] Check it runs on Baskerville