### PR TITLE
Navier stokes refactor: step 1

### DIFF
--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -172,98 +172,39 @@ contains
        tmp_dx3=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i+1))
        tmp_dx4=0.5_dp*(block(g)%deltax(i+1)+block(g)%deltax(i+2))
 
-       theta_1=tmp_dx2/tmp_dx1
-       theta_2=tmp_dx3/tmp_dx2
-       theta_3=tmp_dx4/tmp_dx3
+       theta = [tmp_dx2/tmp_dx1, tmp_dx3/tmp_dx2, tmp_dx4/tmp_dx3]
 
-       f_1=theta_3
-       f_2=2.0_dp*theta_3+theta_3**2.0_dp
-       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-       f_5=1.0_dp/(theta_1*theta_2)
-       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
-        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
-            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
+       f = compute_f(theta)
+       s = compute_s(theta_2, f)
 
-       s51=-1.0_dp/(theta_2**4.0_dp)
-       s52=f_4
-       s53=f_4
-       s54=s51
-       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+       block(g)%ca1_uv(i) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
+       block(g)%ca2_uv(i) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
+       block(g)%ca3_uv(i) = (s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
+       block(g)%ca4_uv(i) = (s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
+       block(g)%ca5_uv(i) = (s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
+       block(g)%ca6_uv(i) = (s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
 
-       s61=-1.0_dp
-       s62=f_8
-       s63=f_8
-       s64=-1.0_dp
-       s65=(f_5+f_8)
-       s66=(f_8-f_6)
-       s67=(f_7+f_8)
+       block(g)%ca1_uw(i) = block(g)%ca1_uv(i)
+       block(g)%ca2_uw(i) = block(g)%ca2_uv(i)
+       block(g)%ca3_uw(i) = block(g)%ca3_uv(i)
+       block(g)%ca4_uw(i) = block(g)%ca4_uv(i)
+       block(g)%ca5_uw(i) = block(g)%ca5_uv(i)
+       block(g)%ca6_uw(i) = block(g)%ca6_uv(i)
 
-       s71=-1.0_dp
-       s72=(1.0_dp+f_4)
-       s73=f_4
-       s74=(f_4-f_1)
-       s75=(f_4-f_2)
-       s76=(f_4-f_3)
+       ak = compute_ak(theta)
 
-       s81=-1.0_dp/(theta_2**4.0_dp)
-       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-       s83=f_8
-       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
+       block(g)%ck1_uv(i) = ak(3)
+       block(g)%ck2_uv(i) = -ak(4)
+       block(g)%ck3_uv(i) = ak(1)+ak(2)
+       block(g)%ck4_uv(i) = -ak(5)
+       block(g)%ck5_uv(i) = ak(6)
+       block(g)%ck6_uv(i) = ak(7)
 
-       s91=-s66*s51
-       s92=s56*s61
-       s93=-(s54*s66+s56*s62)
-       s94=(s56*s64+s66*s52)
-       s95=(s56*s63-s66*s53)
-       s96=(s56*s65-s66*s55)
-       s97=(s56*s67-s66*s57)
-
-       s101=-s85*s71
-       s102=-s85*s72
-       s103=s75*s81
-       s104=s75*s82
-       s105=(s75*s83-s85*s73)
-       s106=(s75*s84-s85*s74)
-       s107=(s75*s86-s85*s76)
-
-       block(g)%ca1_uv(i)=(s97*s101-s107*s91)
-       block(g)%ca1_uw(i)=block(g)%ca1_uv(i)
-       block(g)%ca2_uv(i)=(s97*s102+s107*s93)
-       block(g)%ca2_uw(i)=block(g)%ca2_uv(i)
-       block(g)%ca3_uv(i)=(s95*s107-s105*s97)
-       block(g)%ca3_uw(i)=block(g)%ca3_uv(i)
-       block(g)%ca4_uv(i)=(s94*s107+s104*s97)
-       block(g)%ca4_uw(i)=block(g)%ca4_uv(i)
-       block(g)%ca5_uv(i)=(s97*s103-s107*s92)
-       block(g)%ca5_uw(i)=block(g)%ca5_uv(i)
-       block(g)%ca6_uv(i)=(s97*s106-s107*s96)
-       block(g)%ca6_uw(i)=block(g)%ca6_uv(i)
-
-       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-       ak_3=(1.0_dp+theta_1)
-       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-
-       block(g)%ck1_uv(i)=ak_3
        block(g)%ck1_uw(i)=block(g)%ck1_uv(i)
-       block(g)%ck2_uv(i)=-ak_4
        block(g)%ck2_uw(i)=block(g)%ck2_uv(i)
-       block(g)%ck3_uv(i)=(ak_1+ak_2)
        block(g)%ck3_uw(i)=block(g)%ck3_uv(i)
-       block(g)%ck4_uv(i)=-ak_5
        block(g)%ck4_uw(i)=block(g)%ck4_uv(i)
-       block(g)%ck5_uv(i)=ak_6
        block(g)%ck5_uw(i)=block(g)%ck5_uv(i)
-       block(g)%ck6_uv(i)=ak_7
        block(g)%ck6_uw(i)=block(g)%ck6_uv(i)
        enddo
         END DO
@@ -282,98 +223,39 @@ contains
        tmp_dy3=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j+1))
        tmp_dy4=0.5_dp*(block(g)%deltay(j+1)+block(g)%deltay(j+2))
 
-       theta_1=tmp_dy2/tmp_dy1
-       theta_2=tmp_dy3/tmp_dy2
-       theta_3=tmp_dy4/tmp_dy3
+       theta= [tmp_dy2/tmp_dy1, tmp_dy3/tmp_dy2, tmp_dy4/tmp_dy3]
 
-       f_1=theta_3
-       f_2=2.0_dp*theta_3+theta_3**2.0_dp
-       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-       f_5=1.0_dp/(theta_1*theta_2)
-       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
-        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
-            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
+       f = compute_f(theta)
+       s = compute_s(theta(2), f)
 
-       s51=-1.0_dp/(theta_2**4.0_dp)
-       s52=f_4
-       s53=f_4
-       s54=s51
-       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+       block(g)%ca1_vu(j) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
+       block(g)%ca2_vu(j) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
+       block(g)%ca3_vu(j) = (s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
+       block(g)%ca4_vu(j) = (s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
+       block(g)%ca5_vu(j) = (s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
+       block(g)%ca6_vu(j) = (s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
 
-       s61=-1.0_dp
-       s62=f_8
-       s63=f_8
-       s64=-1.0_dp
-       s65=(f_5+f_8)
-       s66=(f_8-f_6)
-       s67=(f_7+f_8)
-
-       s71=-1.0_dp
-       s72=(1.0_dp+f_4)
-       s73=f_4
-       s74=(f_4-f_1)
-       s75=(f_4-f_2)
-       s76=(f_4-f_3)
-
-       s81=-1.0_dp/(theta_2**4.0_dp)
-       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-       s83=f_8
-       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
-
-       s91=-s66*s51
-       s92=s56*s61
-       s93=-(s54*s66+s56*s62)
-       s94=(s56*s64+s66*s52)
-       s95=(s56*s63-s66*s53)
-       s96=(s56*s65-s66*s55)
-       s97=(s56*s67-s66*s57)
-
-       s101=-s85*s71
-       s102=-s85*s72
-       s103=s75*s81
-       s104=s75*s82
-       s105=(s75*s83-s85*s73)
-       s106=(s75*s84-s85*s74)
-       s107=(s75*s86-s85*s76)
-
-       block(g)%ca1_vu(j)=(s97*s101-s107*s91)
        block(g)%ca1_vw(j)=block(g)%ca1_vu(j)
-       block(g)%ca2_vu(j)=(s97*s102+s107*s93)
        block(g)%ca2_vw(j)=block(g)%ca2_vu(j)
-       block(g)%ca3_vu(j)=(s95*s107-s105*s97)
        block(g)%ca3_vw(j)=block(g)%ca3_vu(j)
-       block(g)%ca4_vu(j)=(s94*s107+s104*s97)
        block(g)%ca4_vw(j)=block(g)%ca4_vu(j)
-       block(g)%ca5_vu(j)=(s97*s103-s107*s92)
        block(g)%ca5_vw(j)=block(g)%ca5_vu(j)
-       block(g)%ca6_vu(j)=(s97*s106-s107*s96)
        block(g)%ca6_vw(j)=block(g)%ca6_vu(j)
 
-       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-       ak_3=(1.0_dp+theta_1)
-       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak = compute_ak(theta)
 
-       block(g)%ck1_vu(j)=ak_3
+       block(g)%ck1_vu(j) = ak(3)
+       block(g)%ck2_vu(j) = -ak(4)
+       block(g)%ck3_vu(j) = ak(1) + ak(2)
+       block(g)%ck4_vu(j) = -ak(5)
+       block(g)%ck5_vu(j) = ak(6)
+       block(g)%ck6_vu(j) = ak(7)
+
        block(g)%ck1_vw(j)=block(g)%ck1_vu(j)
-       block(g)%ck2_vu(j)=-ak_4
        block(g)%ck2_vw(j)=block(g)%ck2_vu(j)
-       block(g)%ck3_vu(j)=(ak_1+ak_2)
        block(g)%ck3_vw(j)=block(g)%ck3_vu(j)
-       block(g)%ck4_vu(j)=-ak_5
        block(g)%ck4_vw(j)=block(g)%ck4_vu(j)
-       block(g)%ck5_vu(j)=ak_6
        block(g)%ck5_vw(j)=block(g)%ck5_vu(j)
-       block(g)%ck6_vu(j)=ak_7
        block(g)%ck6_vw(j)=block(g)%ck6_vu(j)
        enddo
         ENDDO
@@ -392,98 +274,39 @@ contains
        tmp_dz3=0.5_dp*(block(g)%deltaz(k)+block(g)%deltaz(k+1))
        tmp_dz4=0.5_dp*(block(g)%deltaz(k+1)+block(g)%deltaz(k+2))
 
-       theta_1=tmp_dz2/tmp_dz1
-       theta_2=tmp_dz3/tmp_dz2
-       theta_3=tmp_dz4/tmp_dz3
+       theta = [tmp_dz2/tmp_dz1, tmp_dz3/tmp_dz2, tmp_dz4/tmp_dz3]
 
-       f_1=theta_3
-       f_2=2.0_dp*theta_3+theta_3**2.0_dp
-       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-       f_5=1.0_dp/(theta_1*theta_2)
-       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
-        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
-            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
+       f = compute_f(theta)
+       s = compute_s(theta(2), f)
 
-       s51=-1.0_dp/(theta_2**4.0_dp)
-       s52=f_4
-       s53=f_4
-       s54=s51
-       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+       block(g)%ca1_wu(k) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
+       block(g)%ca2_wu(k) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
+       block(g)%ca3_wu(k) = (s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
+       block(g)%ca4_wu(k) = (s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
+       block(g)%ca5_wu(k) = (s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
+       block(g)%ca6_wu(k) = (s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
 
-       s61=-1.0_dp
-       s62=f_8
-       s63=f_8
-       s64=-1.0_dp
-       s65=(f_5+f_8)
-       s66=(f_8-f_6)
-       s67=(f_7+f_8)
-
-       s71=-1.0_dp
-       s72=(1.0_dp+f_4)
-       s73=f_4
-       s74=(f_4-f_1)
-       s75=(f_4-f_2)
-       s76=(f_4-f_3)
-
-       s81=-1.0_dp/(theta_2**4.0_dp)
-       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-       s83=f_8
-       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
-
-       s91=-s66*s51
-       s92=s56*s61
-       s93=-(s54*s66+s56*s62)
-       s94=(s56*s64+s66*s52)
-       s95=(s56*s63-s66*s53)
-       s96=(s56*s65-s66*s55)
-       s97=(s56*s67-s66*s57)
-
-       s101=-s85*s71
-       s102=-s85*s72
-       s103=s75*s81
-       s104=s75*s82
-       s105=(s75*s83-s85*s73)
-       s106=(s75*s84-s85*s74)
-       s107=(s75*s86-s85*s76)
-
-       block(g)%ca1_wu(k)=(s97*s101-s107*s91)
        block(g)%ca1_wv(k)=block(g)%ca1_wu(k)
-       block(g)%ca2_wu(k)=(s97*s102+s107*s93)
        block(g)%ca2_wv(k)=block(g)%ca2_wu(k)
-       block(g)%ca3_wu(k)=(s95*s107-s105*s97)
        block(g)%ca3_wv(k)=block(g)%ca3_wu(k)
-       block(g)%ca4_wu(k)=(s94*s107+s104*s97)
        block(g)%ca4_wv(k)=block(g)%ca4_wu(k)
-       block(g)%ca5_wu(k)=(s97*s103-s107*s92)
        block(g)%ca5_wv(k)=block(g)%ca5_wu(k)
-       block(g)%ca6_wu(k)=(s97*s106-s107*s96)
        block(g)%ca6_wv(k)=block(g)%ca6_wu(k)
 
-       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-       ak_3=(1.0_dp+theta_1)
-       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
+       ak = compute_ak(theta)
 
-       block(g)%ck1_wu(k)=ak_3
+       block(g)%ck1_wu(k) = ak(3)
+       block(g)%ck2_wu(k) = -ak(4)
+       block(g)%ck3_wu(k) = ak(1) + ak(2)
+       block(g)%ck4_wu(k) = -ak(5)
+       block(g)%ck5_wu(k) = ak(6)
+       block(g)%ck6_wu(k) = ak(7)
+
        block(g)%ck1_wv(k)=block(g)%ck1_wu(k)
-       block(g)%ck2_wu(k)=-ak_4
        block(g)%ck2_wv(k)=block(g)%ck2_wu(k)
-       block(g)%ck3_wu(k)=(ak_1+ak_2)
        block(g)%ck3_wv(k)=block(g)%ck3_wu(k)
-       block(g)%ck4_wu(k)=-ak_5
        block(g)%ck4_wv(k)=block(g)%ck4_wu(k)
-       block(g)%ck5_wu(k)=ak_6
        block(g)%ck5_wv(k)=block(g)%ck5_wu(k)
-       block(g)%ck6_wu(k)=ak_7
        block(g)%ck6_wv(k)=block(g)%ck6_wu(k)
        enddo
         END DO

--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -67,10 +67,8 @@ contains
        END DO
 
         DO g=1,nblocks
-        nx_var=block(g)%nx
-        ny_var=block(g)%ny
-        nz_var=block(g)%nz
-       do i=2,nx_var
+
+       do i=2, block(g)%nx
        theta = block(g)%deltax(i:i+2) / block(g)%deltax(i-1:i+1)
        f = compute_f(theta)
        s = compute_s(theta(2), f)
@@ -93,10 +91,8 @@ contains
        enddo
         ENDDO
         DO g=1,nblocks
-        nx_var=block(g)%nx
-        ny_var=block(g)%ny
-        nz_var=block(g)%nz
-       do j=2,ny_var
+
+       do j=2, block(g)%ny
 
        theta = block(g)%deltay(j:j+2) / block(g)%deltay(j-1:j+1)
 
@@ -122,10 +118,8 @@ contains
         ENDDO
 
         DO g=1,nblocks
-        nx_var=block(g)%nx
-        ny_var=block(g)%ny
-        nz_var=block(g)%nz
-       do k=2,nz_var
+
+       do k=2, block(g)%nz
 
        theta = block(g)%deltaz(k:k+2) / block(g)%deltaz(k-1:k+1)
 
@@ -151,10 +145,8 @@ contains
         END DO
 
         DO g=1,nblocks
-        nx_var=block(g)%nx
-        ny_var=block(g)%ny
-        nz_var=block(g)%nz
-       do i=2,nx_var
+
+       do i=2, block(g)%nx
        if(i==2)then
        tmp_dx1=block(g)%deltax(i-1)
        else
@@ -202,10 +194,8 @@ contains
         END DO
 
         DO g=1,nblocks
-        nx_var=block(g)%nx
-        ny_var=block(g)%ny
-        nz_var=block(g)%nz
-       do j=2,ny_var
+
+       do j=2, block(g)%ny
        if(j==2)then
        tmp_dy1=block(g)%deltay(j-1)
        else
@@ -253,10 +243,8 @@ contains
         ENDDO
 
         DO g=1,nblocks
-        nx_var=block(g)%nx
-        ny_var=block(g)%ny
-        nz_var=block(g)%nz
-       do k=2,nz_var
+
+       do k=2, block(g)%nz
        if(k==2)then
        tmp_dz1=block(g)%deltaz(k-1)
        else

--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -73,12 +73,12 @@ contains
        f = compute_f(theta)
        s = compute_s(theta(2), f)
 
-       block(g)%ca1_uu(i)=(s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
-       block(g)%ca2_uu(i)=(s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
-       block(g)%ca3_uu(i)=(s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
-       block(g)%ca4_uu(i)=(s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
-       block(g)%ca5_uu(i)=(s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
-       block(g)%ca6_uu(i)=(s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
+       block(g)%ca1_uu(i) = s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1)
+       block(g)%ca2_uu(i) = s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3)
+       block(g)%ca3_uu(i) = s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7)
+       block(g)%ca4_uu(i) = s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7)
+       block(g)%ca5_uu(i) = s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2)
+       block(g)%ca6_uu(i) = s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6)
 
        ak = compute_ak(theta)
 
@@ -99,12 +99,12 @@ contains
        f = compute_f(theta)
        s = compute_s(theta(2), f)
 
-       block(g)%ca1_vv(j) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
-       block(g)%ca2_vv(j) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
-       block(g)%ca3_vv(j) = (s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
-       block(g)%ca4_vv(j) = (s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
-       block(g)%ca5_vv(j) = (s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
-       block(g)%ca6_vv(j) = (s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
+       block(g)%ca1_vv(j) = s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1)
+       block(g)%ca2_vv(j) = s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3)
+       block(g)%ca3_vv(j) = s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7)
+       block(g)%ca4_vv(j) = s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7)
+       block(g)%ca5_vv(j) = s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2)
+       block(g)%ca6_vv(j) = s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6)
 
        ak = compute_ak(theta)
 
@@ -126,12 +126,12 @@ contains
        f = compute_f(theta)
        s = compute_s(theta(2), f)
 
-       block(g)%ca1_ww(k) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
-       block(g)%ca2_ww(k) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
-       block(g)%ca3_ww(k) = (s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
-       block(g)%ca4_ww(k) = (s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
-       block(g)%ca5_ww(k) = (s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
-       block(g)%ca6_ww(k) = (s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
+       block(g)%ca1_ww(k) = s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1)
+       block(g)%ca2_ww(k) = s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3)
+       block(g)%ca3_ww(k) = s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7)
+       block(g)%ca4_ww(k) = s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7)
+       block(g)%ca5_ww(k) = s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2)
+       block(g)%ca6_ww(k) = s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6)
 
        ak = compute_ak(theta)
 
@@ -161,12 +161,12 @@ contains
        f = compute_f(theta)
        s = compute_s(theta(2), f)
 
-       block(g)%ca1_uv(i) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
-       block(g)%ca2_uv(i) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
-       block(g)%ca3_uv(i) = (s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
-       block(g)%ca4_uv(i) = (s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
-       block(g)%ca5_uv(i) = (s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
-       block(g)%ca6_uv(i) = (s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
+       block(g)%ca1_uv(i) = s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1)
+       block(g)%ca2_uv(i) = s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3)
+       block(g)%ca3_uv(i) = s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7)
+       block(g)%ca4_uv(i) = s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7)
+       block(g)%ca5_uv(i) = s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2)
+       block(g)%ca6_uv(i) = s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6)
 
        block(g)%ca1_uw(i) = block(g)%ca1_uv(i)
        block(g)%ca2_uw(i) = block(g)%ca2_uv(i)
@@ -210,12 +210,12 @@ contains
        f = compute_f(theta)
        s = compute_s(theta(2), f)
 
-       block(g)%ca1_vu(j) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
-       block(g)%ca2_vu(j) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
-       block(g)%ca3_vu(j) = (s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
-       block(g)%ca4_vu(j) = (s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
-       block(g)%ca5_vu(j) = (s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
-       block(g)%ca6_vu(j) = (s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
+       block(g)%ca1_vu(j) = s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1)
+       block(g)%ca2_vu(j) = s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3)
+       block(g)%ca3_vu(j) = s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7)
+       block(g)%ca4_vu(j) = s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7)
+       block(g)%ca5_vu(j) = s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2)
+       block(g)%ca6_vu(j) = s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6)
 
        block(g)%ca1_vw(j)=block(g)%ca1_vu(j)
        block(g)%ca2_vw(j)=block(g)%ca2_vu(j)
@@ -259,12 +259,12 @@ contains
        f = compute_f(theta)
        s = compute_s(theta(2), f)
 
-       block(g)%ca1_wu(k) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
-       block(g)%ca2_wu(k) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
-       block(g)%ca3_wu(k) = (s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
-       block(g)%ca4_wu(k) = (s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
-       block(g)%ca5_wu(k) = (s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
-       block(g)%ca6_wu(k) = (s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
+       block(g)%ca1_wu(k) = s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1)
+       block(g)%ca2_wu(k) = s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3)
+       block(g)%ca3_wu(k) = s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7)
+       block(g)%ca4_wu(k) = s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7)
+       block(g)%ca5_wu(k) = s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2)
+       block(g)%ca6_wu(k) = s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6)
 
        block(g)%ca1_wv(k)=block(g)%ca1_wu(k)
        block(g)%ca2_wv(k)=block(g)%ca2_wu(k)
@@ -1226,7 +1226,7 @@ ENDIF
        s(6, 1) = -1.0_dp
        s(6, 2) = f(8)
        s(6, 3) = f(8)
-       s(6, 4) = -1.0
+       s(6, 4) = -1.0_dp
        s(6, 5) = (f(5)+f(8))
        s(6, 6) = (f(8)-f(6))
        s(6, 7) = (f(7)+f(8))
@@ -1273,5 +1273,5 @@ ENDIF
        ak(5) = ((1.0_dp+theta(1))**2.0_dp)*(theta(3)+theta(3)**2.0_dp)*theta(2)
        ak(6) = (theta(1)**2.0_dp)*theta(2)*(theta(3)+theta(3)**2.0_dp)
        ak(7) = (1.0_dp+theta(1))*(theta(3)+theta(3)**2.0_dp)*theta(2)
-end function compute_ak
+    end function compute_ak
 end module biocfd_navier_stokes

--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -19,6 +19,14 @@ contains
                          tmp_dx1, tmp_dx2, tmp_dx3, tmp_dx4, tmp_dy1, tmp_dy2, tmp_dy3,         &
                          tmp_dy4, tmp_dz1, tmp_dz2, tmp_dz3, tmp_dz4
 
+       real(dp) :: theta(3)
+       real(dp) :: f(8)
+       !> For s we will use special indexing, note that original code
+       !> doesn't have s77 or 87, but we'll just live with that for
+       !> now
+       real(dp) :: s(5:10, 1:7)
+       real(dp) :: ak(7)
+
 
         DO g=1,nblocks
         nx_var=block(g)%nx
@@ -68,87 +76,25 @@ contains
         ny_var=block(g)%ny
         nz_var=block(g)%nz
        do i=2,nx_var
-       theta_1=block(g)%deltax(i)/block(g)%deltax(i-1)
-       theta_2=block(g)%deltax(i+1)/block(g)%deltax(i)
-       theta_3=block(g)%deltax(i+2)/block(g)%deltax(i+1)
+       theta = block(g)%deltax(i:i+2) / block(g)%deltax(i-1:i+1)
+       f = compute_f(theta)
+       s = compute_s(theta(2), f)
 
-        f_1=theta_3
-        f_2=2.0_dp*theta_3+theta_3**2.0_dp
-       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-       f_5=1.0_dp/(theta_1*theta_2)
-       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
-        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
-            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
+       block(g)%ca1_uu(i)=(s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
+       block(g)%ca2_uu(i)=(s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
+       block(g)%ca3_uu(i)=(s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
+       block(g)%ca4_uu(i)=(s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
+       block(g)%ca5_uu(i)=(s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
+       block(g)%ca6_uu(i)=(s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
 
-       s51=-1.0_dp/(theta_2**4.0_dp)
-       s52=f_4
-       s53=f_4
-       s54=s51
-       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+       ak = compute_ak(theta)
 
-       s61=-1.0_dp
-       s62=f_8
-       s63=f_8
-       s64=-1.0
-       s65=(f_5+f_8)
-       s66=(f_8-f_6)
-       s67=(f_7+f_8)
-
-       s71=-1.0_dp
-       s72=(1.0_dp+f_4)
-       s73=f_4
-       s74=(f_4-f_1)
-       s75=(f_4-f_2)
-       s76=(f_4-f_3)
-
-       s81=-1.0_dp/(theta_2**4.0_dp)
-       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-       s83=f_8
-       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
-
-       s91=-s66*s51
-       s92=s56*s61
-       s93=-(s54*s66+s56*s62)
-       s94=(s56*s64+s66*s52)
-       s95=(s56*s63-s66*s53)
-       s96=(s56*s65-s66*s55)
-       s97=(s56*s67-s66*s57)
-
-       s101=-s85*s71
-       s102=-s85*s72
-       s103=s75*s81
-       s104=s75*s82
-       s105=(s75*s83-s85*s73)
-       s106=(s75*s84-s85*s74)
-       s107=(s75*s86-s85*s76)
-
-       block(g)%ca1_uu(i)=(s97*s101-s107*s91)
-       block(g)%ca2_uu(i)=(s97*s102+s107*s93)
-       block(g)%ca3_uu(i)=(s95*s107-s105*s97)
-       block(g)%ca4_uu(i)=(s94*s107+s104*s97)
-       block(g)%ca5_uu(i)=(s97*s103-s107*s92)
-       block(g)%ca6_uu(i)=(s97*s106-s107*s96)
-
-       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-       ak_3=(1.0_dp+theta_1)
-       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-
-       block(g)%ck1_uu(i)=ak_3
-       block(g)%ck2_uu(i)=-ak_4
-       block(g)%ck3_uu(i)=(ak_1+ak_2)
-       block(g)%ck4_uu(i)=-ak_5
-       block(g)%ck5_uu(i)=ak_6
-       block(g)%ck6_uu(i)=ak_7
+       block(g)%ck1_uu(i) = ak(3)
+       block(g)%ck2_uu(i) = -ak(4)
+       block(g)%ck3_uu(i) = ak(1) + ak(2)
+       block(g)%ck4_uu(i) = -ak(5)
+       block(g)%ck5_uu(i) = ak(6)
+       block(g)%ck6_uu(i) = ak(7)
        enddo
         ENDDO
         DO g=1,nblocks
@@ -1558,4 +1504,88 @@ ENDIF
 
        ENDDO
       end subroutine nsMomentum2order
+
+
+    pure function compute_f(theta) result(f)
+        real(dp), intent(in) :: theta(3)
+        real(dp) :: f(8)
+
+        f(1) = theta(3)
+        f(2) = 2.0_dp*theta(3)+theta(3)**2.0_dp
+        f(3) = 3.0_dp*theta(3)+3.0_dp*theta(3)**2.0_dp+theta(3)**3.0_dp
+        f(4) = 4.0_dp*theta(3)+6.0_dp*theta(3)**2.0_dp+4.0_dp*theta(3)**3.0_dp+theta(3)**4.0_dp
+        f(5) = 1.0_dp/(theta(1)*theta(2))
+        f(6) = (2.0_dp*theta(1)+1.0_dp)/((theta(1)**2.0_dp)*(theta(2)**2.0_dp))
+        f(7) = (3.0_dp*theta(1)**2.0_dp+3.0_dp*theta(1)+1.0_dp)/ &
+               ((theta(1)**3.0_dp)*(theta(2)**3.0_dp))
+        f(8) = (4.0_dp*theta(1)**3.0_dp+6.0_dp*theta(1)**2.0_dp+4.0_dp*theta(1)+1.0_dp)/ &
+               ((theta(1)**4.0_dp)*(theta(2)**4.0_dp))
+    end function compute_f
+
+
+    pure function compute_s(theta_2, f) result(s)
+    !> Only need the 2nd element of theta
+       real(dp), intent(in) :: theta_2
+       real(dp), intent(in) :: f(8)
+       real(dp) :: s(5:10, 1:7)
+
+       s(5, 1) = -1.0_dp/(theta_2**4.0_dp)
+       s(5, 2) = f(4)
+       s(5, 3) = f(4)
+       s(5, 4) = s(5, 1)
+       s(5, 5) = -(f(1)/(theta_2**4.0_dp)+f(4)/theta_2)
+       s(5, 6) = (f(4)/(theta_2**2.0_dp)-f(2)/(theta_2**4.0_dp))
+       s(5, 7) = -(f(3)/(theta_2**4.0_dp)+f(4)/(theta_2**3.0_dp))
+
+       s(6, 1) = -1.0_dp
+       s(6, 2) = f(8)
+       s(6, 3) = f(8)
+       s(6, 4) = -1.0
+       s(6, 5) = (f(5)+f(8))
+       s(6, 6) = (f(8)-f(6))
+       s(6, 7) = (f(7)+f(8))
+
+       s(7, 1) = -1.0_dp
+       s(7, 2) = (1.0_dp+f(4))
+       s(7, 3) = f(4)
+       s(7, 4) = (f(4)-f(1))
+       s(7, 5) = (f(4)-f(2))
+       s(7, 6) = (f(4)-f(3))
+
+       s(8, 1) =-1.0_dp/(theta_2**4.0_dp)
+       s(8, 2) =(f(8)+(1.0_dp/theta_2**4.0_dp))
+       s(8, 3) =f(8)
+       s(8, 4) =(f(5)/(theta_2**4.0_dp)-f(8)/theta_2)
+       s(8, 5) =(f(8)/(theta_2**2.0_dp)-f(6)/(theta_2**4.0_dp))
+       s(8, 6) =(f(7)/(theta_2**4.0_dp)-f(8)/(theta_2**3.0_dp))
+
+       s(9, 1) = -s(6, 6) * s(5, 1)
+       s(9, 2) = s(5, 6) * s(6, 1)
+       s(9, 3) = -(s(5, 4) * s(6, 6) + s(5, 6) * s(6, 2))
+       s(9, 4) = (s(5, 6) * s(6, 4)+ s(6, 6) * s(5, 2))
+       s(9, 5) = (s(5, 6) * s(6, 3)- s(6, 6) * s(5, 3))
+       s(9, 6) = (s(5, 6) * s(6, 5)- s(6, 6) * s(5, 5))
+       s(9, 7) = (s(5, 6) * s(6, 7)- s(6, 6) * s(5, 7))
+
+       s(10, 1) = -s(8, 5) * s(7, 1)
+       s(10, 2) = -s(8, 5) * s(7, 2)
+       s(10, 3) = s(7, 5) * s(8, 1)
+       s(10, 4) = s(7, 5) * s(8, 2)
+       s(10, 5) = (s(7, 5) * s(8, 3) - s(8, 5) * s(7, 3))
+       s(10, 6) = (s(7, 5) * s(8, 4) - s(8, 5) * s(7, 4))
+       s(10, 7) = (s(7, 5) * s(8, 6) - s(8, 5) * s(7, 6))
+    end function compute_s
+
+    pure function compute_ak(theta) result(ak)
+       real(dp), intent(in) :: theta(3)
+       real(dp) :: ak(7)
+
+       ak(1) = (1.0_dp+2.0_dp*theta(1))*(theta(3)+theta(3)**2.0_dp)*theta(2)
+       ak(2) = (1.0_dp+theta(1))*(2.0_dp*theta(3)+theta(3)**2.0_dp)
+       ak(3) = (1.0_dp+theta(1))
+       ak(4) = (1.0_dp+theta(1))*((1.0_dp+theta(3))**2.0_dp)
+       ak(5) = ((1.0_dp+theta(1))**2.0_dp)*(theta(3)+theta(3)**2.0_dp)*theta(2)
+       ak(6) = (theta(1)**2.0_dp)*theta(2)*(theta(3)+theta(3)**2.0_dp)
+       ak(7) = (1.0_dp+theta(1))*(theta(3)+theta(3)**2.0_dp)*theta(2)
+end function compute_ak
 end module biocfd_navier_stokes

--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -106,83 +106,26 @@ contains
        theta_2=block(g)%deltay(j+1)/block(g)%deltay(j)
        theta_3=block(g)%deltay(j+2)/block(g)%deltay(j+1)
 
-       f_1=theta_3
-       f_2=2.0_dp*theta_3+theta_3**2.0_dp
-       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-       f_5=1.0_dp/(theta_1*theta_2)
-       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
-        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
-            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
+       theta = block(g)%deltay(j:j+2) / block(g)%deltay(j-1:j+1)
 
-       s51=-1.0_dp/(theta_2**4.0_dp)
-       s52=f_4
-       s53=f_4
-       s54=s51
-       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+       f = compute_f(theta)
+       s = compute_s(theta(2), f)
 
-       s61=-1.0_dp
-       s62=f_8
-       s63=f_8
-       s64=-1.0_dp
-       s65=(f_5+f_8)
-       s66=(f_8-f_6)
-       s67=(f_7+f_8)
+       block(g)%ca1_vv(j) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
+       block(g)%ca2_vv(j) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
+       block(g)%ca3_vv(j) = (s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
+       block(g)%ca4_vv(j) = (s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
+       block(g)%ca5_vv(j) = (s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
+       block(g)%ca6_vv(j) = (s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
 
-       s71=-1.0_dp
-       s72=(1.0_dp+f_4)
-       s73=f_4
-       s74=(f_4-f_1)
-       s75=(f_4-f_2)
-       s76=(f_4-f_3)
+       ak = compute_ak(theta)
 
-       s81=-1.0_dp/(theta_2**4.0_dp)
-       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-       s83=f_8
-       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
-
-       s91=-s66*s51
-       s92=s56*s61
-       s93=-(s54*s66+s56*s62)
-       s94=(s56*s64+s66*s52)
-       s95=(s56*s63-s66*s53)
-       s96=(s56*s65-s66*s55)
-       s97=(s56*s67-s66*s57)
-
-       s101=-s85*s71
-       s102=-s85*s72
-       s103=s75*s81
-       s104=s75*s82
-       s105=(s75*s83-s85*s73)
-       s106=(s75*s84-s85*s74)
-       s107=(s75*s86-s85*s76)
-
-       block(g)%ca1_vv(j)=(s97*s101-s107*s91)
-       block(g)%ca2_vv(j)=(s97*s102+s107*s93)
-       block(g)%ca3_vv(j)=(s95*s107-s105*s97)
-       block(g)%ca4_vv(j)=(s94*s107+s104*s97)
-       block(g)%ca5_vv(j)=(s97*s103-s107*s92)
-       block(g)%ca6_vv(j)=(s97*s106-s107*s96)
-
-       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-       ak_3=(1.0_dp+theta_1)
-       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-
-       block(g)%ck1_vv(j)=ak_3
-       block(g)%ck2_vv(j)=-ak_4
-       block(g)%ck3_vv(j)=(ak_1+ak_2)
-       block(g)%ck4_vv(j)=-ak_5
-       block(g)%ck5_vv(j)=ak_6
-       block(g)%ck6_vv(j)=ak_7
+       block(g)%ck1_vv(j) = ak(3)
+       block(g)%ck2_vv(j) = -ak(4)
+       block(g)%ck3_vv(j) = ak(1) + ak(2)
+       block(g)%ck4_vv(j) = -ak(5)
+       block(g)%ck5_vv(j) = ak(6)
+       block(g)%ck6_vv(j) = ak(7)
        enddo
         ENDDO
 
@@ -191,87 +134,27 @@ contains
         ny_var=block(g)%ny
         nz_var=block(g)%nz
        do k=2,nz_var
-       theta_1=block(g)%deltaz(k)/block(g)%deltaz(k-1)
-       theta_2=block(g)%deltaz(k+1)/block(g)%deltaz(k)
-       theta_3=block(g)%deltaz(k+2)/block(g)%deltaz(k+1)
 
-       f_1=theta_3
-       f_2=2.0_dp*theta_3+theta_3**2.0_dp
-       f_3=3.0_dp*theta_3+3.0_dp*theta_3**2.0_dp+theta_3**3.0_dp
-       f_4=4.0_dp*theta_3+6.0_dp*theta_3**2.0_dp+4.0_dp*theta_3**3.0_dp+theta_3**4.0_dp
-       f_5=1.0_dp/(theta_1*theta_2)
-       f_6=(2.0_dp*theta_1+1.0_dp)/((theta_1**2.0_dp)*(theta_2**2.0_dp))
-       f_7=(3.0_dp*theta_1**2.0_dp+3.0_dp*theta_1+1.0_dp)/((theta_1**3.0_dp)*(theta_2**3.0_dp))
-        f_8=(4.0_dp*theta_1**3.0_dp+6.0_dp*theta_1**2.0_dp+4.0_dp*theta_1+1.0_dp)/&
-            ((theta_1**4.0_dp)*(theta_2**4.0_dp))
+       theta = block(g)%deltaz(k:k+2) / block(g)%deltaz(k-1:k+1)
 
-       s51=-1.0_dp/(theta_2**4.0_dp)
-       s52=f_4
-       s53=f_4
-       s54=s51
-       s55=-(f_1/(theta_2**4.0_dp)+f_4/theta_2)
-       s56=(f_4/(theta_2**2.0_dp)-f_2/(theta_2**4.0_dp))
-       s57=-(f_3/(theta_2**4.0_dp)+f_4/(theta_2**3.0_dp))
+       f = compute_f(theta)
+       s = compute_s(theta(2), f)
 
-       s61=-1.0_dp
-       s62=f_8
-       s63=f_8
-       s64=-1.0_dp
-       s65=(f_5+f_8)
-       s66=(f_8-f_6)
-       s67=(f_7+f_8)
+       block(g)%ca1_ww(k) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
+       block(g)%ca2_ww(k) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))
+       block(g)%ca3_ww(k) = (s(9, 5) * s(10, 7) - s(10, 5) * s(9, 7))
+       block(g)%ca4_ww(k) = (s(9, 4) * s(10, 7) + s(10, 4) * s(9, 7))
+       block(g)%ca5_ww(k) = (s(9, 7) * s(10, 3) - s(10, 7) * s(9, 2))
+       block(g)%ca6_ww(k) = (s(9, 7) * s(10, 6) - s(10, 7) * s(9, 6))
 
-       s71=-1.0_dp
-       s72=(1.0_dp+f_4)
-       s73=f_4
-       s74=(f_4-f_1)
-       s75=(f_4-f_2)
-       s76=(f_4-f_3)
+       ak = compute_ak(theta)
 
-       s81=-1.0_dp/(theta_2**4.0_dp)
-       s82=(f_8+(1.0_dp/theta_2**4.0_dp))
-       s83=f_8
-       s84=(f_5/(theta_2**4.0_dp)-f_8/theta_2)
-       s85=(f_8/(theta_2**2.0_dp)-f_6/(theta_2**4.0_dp))
-       s86=(f_7/(theta_2**4.0_dp)-f_8/(theta_2**3.0_dp))
-
-       s91=-s66*s51
-       s92=s56*s61
-       s93=-(s54*s66+s56*s62)
-       s94=(s56*s64+s66*s52)
-       s95=(s56*s63-s66*s53)
-       s96=(s56*s65-s66*s55)
-       s97=(s56*s67-s66*s57)
-
-       s101=-s85*s71
-       s102=-s85*s72
-       s103=s75*s81
-       s104=s75*s82
-       s105=(s75*s83-s85*s73)
-       s106=(s75*s84-s85*s74)
-       s107=(s75*s86-s85*s76)
-
-       block(g)%ca1_ww(k)=(s97*s101-s107*s91)
-       block(g)%ca2_ww(k)=(s97*s102+s107*s93)
-       block(g)%ca3_ww(k)=(s95*s107-s105*s97)
-       block(g)%ca4_ww(k)=(s94*s107+s104*s97)
-       block(g)%ca5_ww(k)=(s97*s103-s107*s92)
-       block(g)%ca6_ww(k)=(s97*s106-s107*s96)
-
-       ak_1=(1.0_dp+2.0_dp*theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_2=(1.0_dp+theta_1)*(2.0_dp*theta_3+theta_3**2.0_dp)
-       ak_3=(1.0_dp+theta_1)
-       ak_4=(1.0_dp+theta_1)*((1.0_dp+theta_3)**2.0_dp)
-       ak_5=((1.0_dp+theta_1)**2.0_dp)*(theta_3+theta_3**2.0_dp)*theta_2
-       ak_6=(theta_1**2.0_dp)*theta_2*(theta_3+theta_3**2.0_dp)
-       ak_7=(1.0_dp+theta_1)*(theta_3+theta_3**2.0_dp)*theta_2
-
-       block(g)%ck1_ww(k)=ak_3
-       block(g)%ck2_ww(k)=-ak_4
-       block(g)%ck3_ww(k)=(ak_1+ak_2)
-       block(g)%ck4_ww(k)=-ak_5
-       block(g)%ck5_ww(k)=ak_6
-       block(g)%ck6_ww(k)=ak_7
+       block(g)%ck1_ww(k) = ak(3)
+       block(g)%ck2_ww(k) = -ak(4)
+       block(g)%ck3_ww(k) = ak(1) + ak(2)
+       block(g)%ck4_ww(k) = -ak(5)
+       block(g)%ck5_ww(k) = ak(6)
+       block(g)%ck6_ww(k) = ak(7)
        enddo
         END DO
 

--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -11,13 +11,8 @@ contains
 
        SUBROUTINE non_uni_coeff
        INTEGER  (dp) :: i, j, k, g, nx_var, ny_var, nz_var
-       REAL (dp)   :: f_1, f_2, f_3, f_4, f_5, f_6, f_7, f_8,                             &
-                         s51, s52, s53, s54, s55, s56, s57, s61, s62, s63, s64, s65, s66, s67,  &
-                         s71, s72, s73, s74, s75, s76, s81, s82, s83, s84, s85, s86, s91, s92,  &
-                         s93, s94, s95, s96, s97, s101, s102, s103, s104, s105, s106, s107,     &
-                         ak_1, ak_2, ak_3, ak_4, ak_5, ak_6, ak_7, theta_1, theta_2, theta_3,   &
-                         tmp_dx1, tmp_dx2, tmp_dx3, tmp_dx4, tmp_dy1, tmp_dy2, tmp_dy3,         &
-                         tmp_dy4, tmp_dz1, tmp_dz2, tmp_dz3, tmp_dz4
+       REAL (dp)   :: tmp_dx1, tmp_dx2, tmp_dx3, tmp_dx4, tmp_dy1, tmp_dy2, tmp_dy3,         &
+                      tmp_dy4, tmp_dz1, tmp_dz2, tmp_dz3, tmp_dz4
 
        real(dp) :: theta(3)
        real(dp) :: f(8)
@@ -102,9 +97,6 @@ contains
         ny_var=block(g)%ny
         nz_var=block(g)%nz
        do j=2,ny_var
-       theta_1=block(g)%deltay(j)/block(g)%deltay(j-1)
-       theta_2=block(g)%deltay(j+1)/block(g)%deltay(j)
-       theta_3=block(g)%deltay(j+2)/block(g)%deltay(j+1)
 
        theta = block(g)%deltay(j:j+2) / block(g)%deltay(j-1:j+1)
 
@@ -175,7 +167,7 @@ contains
        theta = [tmp_dx2/tmp_dx1, tmp_dx3/tmp_dx2, tmp_dx4/tmp_dx3]
 
        f = compute_f(theta)
-       s = compute_s(theta_2, f)
+       s = compute_s(theta(2), f)
 
        block(g)%ca1_uv(i) = (s(9, 7) * s(10, 1) - s(10, 7) * s(9, 1))
        block(g)%ca2_uv(i) = (s(9, 7) * s(10, 2) + s(10, 7) * s(9, 3))


### PR DESCRIPTION
This is the start of the refactor of Navier-Stokes.

## What has changed
- Rather than using e.g. `f_1, f_2, f_3,` etc, use a 1D array (2D in the case of s)
  - `theta_n` -> `theta(n)`
  - `f_n` -> `f(n)`
  - `s_mn` -> `s(m, n)`
  - `ak_n` -> `ak(n)`
- Added pure functions to compute `f`, `s`, and `ak`, and use these in `non_uni_coeff`
- When looping in `non_uni_coeff` directly use e.g. `block(g)%nx` rather than reassigning to `nx_var` (not yet done for allocation of arrays, see next section!)

## What will come next 
Open to discussion where the next changes occur, but I'd propose another PR after this is merged
- Make e.g. `block(g)%ca{1..6}_uu` into a 2D array with one of the dimension 6 in length. This isn't done here because it is slightly more involved - same for e.g. `block(g)%ck{1..6}_uu`
- Two new functions along the lines of `compute_ca(theta)` and `compute_ck(theta)`, which will directly calculate those values (will call existing `calculate` functions)
- Have a single `do g=1, nblocks` loop inside `non_uni_coeff` rather than several