### PR TITLE
Remove unneeded sqrt calculation from retagging

### DIFF
--- a/src/Search.f90
+++ b/src/Search.f90
@@ -728,8 +728,7 @@ module biocfd_search
         INTEGER(int64) ::  n, g, m, i, j, k, i1, j1, k1, nn, &
                                nel2Pnt, nel2Cen, sumNodeID
         INTEGER            :: flcnt, sdcnt, ibcnt
-        REAL(dp)      :: n1x, n1y, n1z, n2x, n2y, n2z, minDis, minDis1, dis_cen, dis_pnt, &
-                              n2dotn, cent_x, cent_y, cent_z
+        REAL(dp)      :: minDis, minDis1, dis_cen, dis_pnt, n2dotn
 
        DO g=blk_start,nblocks
         if( block(g)%blk_mv_tag ==0)then

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -748,6 +748,7 @@ module biocfd_search
 
                !$acc loop seq
                DO m = 1, block(g)%ibElems
+                  ! No need to take sqrt because we just use for distance comparison
                   dis_cen  = (block(g)%xp(i)-block(g)%xcent(m))**2 &
                            + (block(g)%yp(j)-block(g)%ycent(m))**2 &
                            + (block(g)%zp(k)-block(g)%zcent(m))**2

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -748,11 +748,11 @@ module biocfd_search
 
                !$acc loop seq
                DO m = 1, block(g)%ibElems
-                  dis_cen  = (block(g)%yp(j)-block(g)%ycent(m))**2 &
-                           + (block(g)%xp(i)-block(g)%xcent(m))**2  &
+                  dis_cen  = (block(g)%xp(i)-block(g)%xcent(m))**2 &
+                           + (block(g)%yp(j)-block(g)%ycent(m))**2 &
                            + (block(g)%zp(k)-block(g)%zcent(m))**2
-                  dis_pnt  = (block(g)%y1(j)-block(g)%ycent(m))**2 &
-                           + (block(g)%x1(i)-block(g)%xcent(m))**2  &
+                  dis_pnt  = (block(g)%x1(i)-block(g)%xcent(m))**2 &
+                           + (block(g)%y1(j)-block(g)%ycent(m))**2 &
                            + (block(g)%z1(k)-block(g)%zcent(m))**2
                   IF (dis_cen<minDis) THEN
                      minDis    = dis_cen
@@ -971,13 +971,13 @@ block(g)%fluidCellCount = flcnt
         cent_y = block(g)%ycent(m)
         cent_z = block(g)%zcent(m)
         ! No need to take sqrt because we just use for distance comparison
-              dis   =  (n1y-cent_y)**2 + (n1x-cent_x)**2 + (n1z-cent_z)**2
-              dis1  =  (n1y-cent_y)**2 + (n2x-cent_x)**2 + (n1z-cent_z)**2
-              dis2  =  (n1y-cent_y)**2 + (n3x-cent_x)**2 + (n1z-cent_z)**2
-              dis3  =  (n2y-cent_y)**2 + (n1x-cent_x)**2 + (n1z-cent_z)**2
-              dis4  =  (n3y-cent_y)**2 + (n1x-cent_x)**2 + (n1z-cent_z)**2
-              dis5  =  (n1y-cent_y)**2 + (n1x-cent_x)**2 + (n2z-cent_z)**2
-              dis6  =  (n1y-cent_y)**2 + (n1x-cent_x)**2 + (n3z-cent_z)**2
+              dis   =  (n1x-cent_x)**2 + (n1y-cent_y)**2 + (n1z-cent_z)**2
+              dis1  =  (n2x-cent_x)**2 + (n1y-cent_y)**2 + (n1z-cent_z)**2
+              dis2  =  (n3x-cent_x)**2 + (n1y-cent_y)**2 + (n1z-cent_z)**2
+              dis3  =  (n1x-cent_x)**2 + (n2y-cent_y)**2 + (n1z-cent_z)**2
+              dis4  =  (n1x-cent_x)**2 + (n3y-cent_y)**2 + (n1z-cent_z)**2
+              dis5  =  (n1x-cent_x)**2 + (n1y-cent_y)**2 + (n2z-cent_z)**2
+              dis6  =  (n1x-cent_x)**2 + (n1y-cent_y)**2 + (n3z-cent_z)**2
               IF (dis<minDis) THEN
                  minDis   = dis
                  nel2p    = m

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -747,21 +747,14 @@ module biocfd_search
                minDis  = 1e14_dp
                minDis1 = 1e14_dp
 
-               n1x = block(g)%xp(i)
-               n1y = block(g)%yp(j)
-               n1z = block(g)%zp(k)
-
-               n2x = block(g)%x1(i)
-               n2y = block(g)%y1(j)
-               n2z = block(g)%z1(k)
-
                !$acc loop seq
                DO m = 1, block(g)%ibElems
-               cent_x = block(g)%xcent(m)
-               cent_y = block(g)%ycent(m)
-               cent_z = block(g)%zcent(m)
-                  dis_cen  = dsqrt( (n1y-cent_y)**2 + (n1x-cent_x)**2  + (n1z-cent_z)**2)
-                  dis_pnt  = dsqrt( (n2y-cent_y)**2 + (n2x-cent_x)**2  + (n2z-cent_z)**2)
+                  dis_cen  = (block(g)%yp(j)-block(g)%ycent(m))**2 &
+                           + (block(g)%xp(i)-block(g)%xcent(m))**2  &
+                           + (block(g)%zp(k)-block(g)%zcent(m))**2
+                  dis_pnt  = (block(g)%y1(j)-block(g)%ycent(m))**2 &
+                           + (block(g)%x1(i)-block(g)%xcent(m))**2  &
+                           + (block(g)%z1(k)-block(g)%zcent(m))**2
                   IF (dis_cen<minDis) THEN
                      minDis    = dis_cen
                      nel2Cen   = m
@@ -780,9 +773,9 @@ module biocfd_search
                         block(g)%cell(i,j,k) = 2
                ENDIF
 
-                           n2dotn  = (n2x - block(g)%xcent(nel2Pnt))*block(g)%cosAlpha(nel2Pnt) + &
-                              (n2y - block(g)%ycent(nel2Pnt))*block(g)%cosBeta(nel2Pnt)  + &
-                              (n2z - block(g)%zcent(nel2Pnt))*block(g)%cosGamma(nel2Pnt)
+               n2dotn  = (block(g)%x1(i) - block(g)%xcent(nel2Pnt)) * block(g)%cosAlpha(nel2Pnt) + &
+                         (block(g)%y1(j) - block(g)%ycent(nel2Pnt)) * block(g)%cosBeta(nel2Pnt)  + &
+                         (block(g)%z1(k) - block(g)%zcent(nel2Pnt)) * block(g)%cosGamma(nel2Pnt)
 
                IF (n2dotn>=-1e-16_dp) THEN
                   block(g)%nodeIdTag(i,j,k) = 0

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -970,13 +970,14 @@ block(g)%fluidCellCount = flcnt
         cent_x = block(g)%xcent(m)
         cent_y = block(g)%ycent(m)
         cent_z = block(g)%zcent(m)
-              dis   = dsqrt( (n1y-cent_y)**2 + (n1x-cent_x)**2 + (n1z-cent_z)**2 )
-              dis1  = dsqrt( (n1y-cent_y)**2 + (n2x-cent_x)**2 + (n1z-cent_z)**2 )
-              dis2  = dsqrt( (n1y-cent_y)**2 + (n3x-cent_x)**2 + (n1z-cent_z)**2 )
-              dis3  = dsqrt( (n2y-cent_y)**2 + (n1x-cent_x)**2 + (n1z-cent_z)**2 )
-              dis4  = dsqrt( (n3y-cent_y)**2 + (n1x-cent_x)**2 + (n1z-cent_z)**2 )
-              dis5  = dsqrt( (n1y-cent_y)**2 + (n1x-cent_x)**2 + (n2z-cent_z)**2 )
-              dis6  = dsqrt( (n1y-cent_y)**2 + (n1x-cent_x)**2 + (n3z-cent_z)**2 )
+        ! No need to take sqrt because we just use for distance comparison
+              dis   =  (n1y-cent_y)**2 + (n1x-cent_x)**2 + (n1z-cent_z)**2
+              dis1  =  (n1y-cent_y)**2 + (n2x-cent_x)**2 + (n1z-cent_z)**2
+              dis2  =  (n1y-cent_y)**2 + (n3x-cent_x)**2 + (n1z-cent_z)**2
+              dis3  =  (n2y-cent_y)**2 + (n1x-cent_x)**2 + (n1z-cent_z)**2
+              dis4  =  (n3y-cent_y)**2 + (n1x-cent_x)**2 + (n1z-cent_z)**2
+              dis5  =  (n1y-cent_y)**2 + (n1x-cent_x)**2 + (n2z-cent_z)**2
+              dis6  =  (n1y-cent_y)**2 + (n1x-cent_x)**2 + (n3z-cent_z)**2
               IF (dis<minDis) THEN
                  minDis   = dis
                  nel2p    = m


### PR DESCRIPTION
There is no need to perform a `sqrt` inside this part of `selectiveretagging_th`. We have done the same in the `tagging_th` subroutine previously.

Side-by-side diff of kernel stats from running 20 iterations on Baskerville (A100). Old on left, new on right.

```diff
selectiveretagging_th  NVIDIA  devicenum=0                      selectiveretagging_th  NVIDIA  devicenum=0
    time(us): 52,458,322                                      |     time(us): 20,849,843
```

Edit: I also removed `sqrt`s from a similar block of code in `computenormdistance`