### PR TITLE
Hdf5 writer

### DIFF
--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -55,7 +55,11 @@ jobs:
       - uses: fortran-lang/setup-fpm@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-  
+
+      - run: |
+          # Install hdf5 dependency
+          sudo apt install libhdf5-dev
+
       - run: |
           # Build and test code using FPM
           fpm test

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ inputdata
 
 # msh files
 *.msh
+
+# hdf5 files
+*.h5

--- a/app/main.f90
+++ b/app/main.f90
@@ -17,10 +17,11 @@
         use biocfd_last_conditions, only: lastConditions
         use biocfd_coefficient_matrix, only: coefficientMatrix
         use biocfd_navier_stokes, only: non_uni_coeff, nsmomentum2order
+        use biocfd_write_output_corner1, only: body_plot, writeresult
 #if USE_HDF5 == 1
-  use biocfd_write_output_corner1, only: writeOutput1_hdf5, body_plot, writeresult
+        use biocfd_write_output_corner1, only: write_output => write_output_hdf5
 #else
-  use biocfd_write_output_corner1, only: writeOutput1, body_plot, writeresult
+        use biocfd_write_output_corner1, only: write_output => write_output_ascii
 #endif
         use biocfd_forcing, only: pressureForcing1, pressureforcingfield, pressureforcingghost, &
              velocityforcing1, velocityforcingfield, velocityforcingghost
@@ -58,11 +59,7 @@
         CALL non_uni_coeff
         totime = totime + deltat
         st_flag=0
-#if USE_HDF5 == 1
-        CALL writeOutput1_hdf5
-#else
-        CALL writeOutput1
-#endif
+        CALL write_output
         coarse_flcnt_check=0
         print*, 'adam'
         DO
@@ -78,11 +75,7 @@
         CALL poissonSolver
         print *,7
         CALL pressureForcing1
-#if USE_HDF5 == 1
-        CALL writeOutput1_hdf5
-#else
-        CALL writeOutput1
-#endif
+        CALL write_output
         !$acc wait
         CALL writeResult
         !$acc wait

--- a/app/main.f90
+++ b/app/main.f90
@@ -17,7 +17,11 @@
         use biocfd_last_conditions, only: lastConditions
         use biocfd_coefficient_matrix, only: coefficientMatrix
         use biocfd_navier_stokes, only: non_uni_coeff, nsmomentum2order
-        use biocfd_write_output_corner1, only: writeOutput1, body_plot, writeresult
+#if USE_HDF5 == 1
+  use biocfd_write_output_corner1, only: writeOutput1_hdf5, body_plot, writeresult
+#else
+  use biocfd_write_output_corner1, only: writeOutput1, body_plot, writeresult
+#endif
         use biocfd_forcing, only: pressureForcing1, pressureforcingfield, pressureforcingghost, &
              velocityforcing1, velocityforcingfield, velocityforcingghost
         IMPLICIT NONE
@@ -54,7 +58,11 @@
         CALL non_uni_coeff
         totime = totime + deltat
         st_flag=0
+#if USE_HDF5 == 1
+        CALL writeOutput1_hdf5
+#else
         CALL writeOutput1
+#endif
         coarse_flcnt_check=0
         print*, 'adam'
         DO
@@ -70,7 +78,11 @@
         CALL poissonSolver
         print *,7
         CALL pressureForcing1
+#if USE_HDF5 == 1
+        CALL writeOutput1_hdf5
+#else
         CALL writeOutput1
+#endif
         !$acc wait
         CALL writeResult
         !$acc wait

--- a/fpm.toml
+++ b/fpm.toml
@@ -6,7 +6,6 @@ auto-executables = true
 auto-tests = true
 auto-examples = true
 external-modules = ["hdf5"]
-link = ["hdf5", "hdf5_fortran"]
 
 [preprocess]
 cpp.suffixes = ["f90"]

--- a/fpm.toml
+++ b/fpm.toml
@@ -6,6 +6,7 @@ auto-executables = true
 auto-tests = true
 auto-examples = true
 external-modules = ["hdf5"]
+link = ["hdf5", "hdf5_fortran"]
 
 [preprocess]
 cpp.suffixes = ["f90"]

--- a/fpm.toml
+++ b/fpm.toml
@@ -6,12 +6,10 @@ auto-executables = true
 auto-tests = true
 auto-examples = true
 external-modules = ["hdf5"]
-link = ["hdf5", "hdf5_fortran"]
 
 [preprocess]
-cpp.suffixes = ["F90", "f90"]
-cpp.directories = ["src/"]
-cpp.macros = ["USE_HDF5=0"]
+cpp.suffixes = ["f90"]
+cpp.macros = ["USE_HDF5=1"]
 
 [install]
 library = false

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,9 +1,18 @@
 name = "Bio-CFD"
+dependencies.hdf5 = "*"
 version = "0.1.0"
 [build]
 auto-executables = true
 auto-tests = true
 auto-examples = true
+external-modules = ["hdf5"]
+link = ["hdf5", "hdf5_fortran"]
+
+[preprocess]
+cpp.suffixes = ["F90", "f90"]
+cpp.directories = ["src/"]
+cpp.macros = ["USE_HDF5=0"]
+
 [install]
 library = false
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -9,7 +9,7 @@ external-modules = ["hdf5"]
 
 [preprocess]
 cpp.suffixes = ["f90"]
-cpp.macros = ["USE_HDF5=1"]
+cpp.macros = ["USE_HDF5=0"]
 
 [install]
 library = false

--- a/src/WriteOutput_corner1.f90
+++ b/src/WriteOutput_corner1.f90
@@ -2,7 +2,9 @@ module biocfd_write_output_corner1
   use, intrinsic :: iso_fortran_env, only: dp => real64, int8,int16,int32,int64
   ! allow(use-all) - TODO: Aim to fix this in the future
   use global
+#if USE_HDF5 == 1
   use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int
+#endif
   implicit none
 
   private

--- a/src/WriteOutput_corner1.f90
+++ b/src/WriteOutput_corner1.f90
@@ -233,22 +233,22 @@ contains
 
     if (.not. dataset_exists) then
       ! Create dataset if it doesn't exist already
-      call h5dcreate_f(group_id,key,H5T_NATIVE_INTEGER,dspace_id,dset_id,error)
+      call h5dcreate_f(group_id,key,H5T_STD_I64LE,dspace_id,dset_id,error)
     end if
 
     if (present(array_input_1d)) then
       ! Write to dataset
-      call h5dwrite_f(dset_id,H5T_NATIVE_INTEGER,array_input_1d,data_dims,error)
+      call h5dwrite_f(dset_id,H5T_STD_I64LE,array_input_1d,data_dims,error)
     end if
 
     if (present(array_input_2d)) then
       ! Write to dataset
-      call h5dwrite_f(dset_id,H5T_NATIVE_INTEGER,array_input_2d,data_dims,error)
+      call h5dwrite_f(dset_id,H5T_STD_I64LE,array_input_2d,data_dims,error)
     end if
 
     if (present(array_input_3d)) then
       ! Write to dataset
-       call h5dwrite_f(dset_id,H5T_NATIVE_INTEGER,array_input_3d,data_dims,error)
+       call h5dwrite_f(dset_id,H5T_STD_I64LE,array_input_3d,data_dims,error)
     end if
 
     ! Close dataset

--- a/src/WriteOutput_corner1.f90
+++ b/src/WriteOutput_corner1.f90
@@ -2,281 +2,27 @@ module biocfd_write_output_corner1
   use, intrinsic :: iso_fortran_env, only: dp => real64, int8,int16,int32,int64
   ! allow(use-all) - TODO: Aim to fix this in the future
   use global
-#if USE_HDF5 == 1
-  use hdf5
-#endif
+  use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int
   implicit none
 
   private
 
 #if USE_HDF5 == 1
-  public :: writeOutput1_hdf5, body_plot, writeresult
+  public :: write_output_hdf5, body_plot, writeresult
 #else
-  public :: writeOutput1, body_plot, writeresult
+  public :: write_output_ascii, body_plot, writeresult
 #endif
 
 contains
 
 #if USE_HDF5 == 1
-  subroutine hdf5_write_real(filename,scalar_input,&
-                             array_input_1d,array_input_2d,array_input_3d,key,group)
-
-    character(len=*), intent(in) :: filename
-    real (dp), allocatable, optional, intent(in) :: array_input_1d(:)
-    real (dp), allocatable, optional, intent(in) :: array_input_2d(:,:)
-    real (dp), allocatable, optional, intent(in) :: array_input_3d(:,:,:)
-    real (dp), optional, intent (in) :: scalar_input
-    character(len=*), intent(in) :: key, group
-    character(len=20) :: dataset_location
-    integer(hsize_t),allocatable :: data_dims(:)
-    integer(hid_t) :: file_id, dspace_id, dset_id, group_id
-    integer (int32) :: space_rank
-    integer (int8) ::arguments_present
-    integer :: error
-    logical :: file_exists, dataset_exists, group_exists
-    arguments_present=0
-    if (present(scalar_input)) then
-      arguments_present = arguments_present + 1
-    end if
-
-    if (present(array_input_1d)) then
-      if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
-      end if
-      arguments_present = arguments_present + 1
-      allocate(data_dims(1))
-      data_dims(1) = size(array_input_1d,1)
-      space_rank = 1
-    end if
-
-    if (present(array_input_2d)) then
-      if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
-      end if
-      arguments_present = arguments_present + 1
-      allocate(data_dims(2))
-      data_dims(1) = size(array_input_2d,1)
-      data_dims(2) = size(array_input_2d,2)
-      space_rank = 2
-    end if
-
-    if (present(array_input_3d)) then
-      if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
-      end if
-      allocate(data_dims(3))
-      data_dims(1) = size(array_input_3d,1)
-      data_dims(2) = size(array_input_3d,2)
-      data_dims(3) = size(array_input_3d,3)
-      space_rank = 3
-    end if
-
-    ! Initialize Fortran interface.
-    call h5open_f(error)
-
-    inquire(file=trim(filename), exist=file_exists )
-
-    if (file_exists) then
-      ! Open an existing file.
-      call h5fopen_f(trim(filename), h5F_acc_rdwr_f, file_id, error)
-    else
-      ! Create file requested
-      call h5fcreate_f(trim(filename), h5f_acc_excl_f, file_id, error)
-    end if
-
-    ! Check if the group exists
-    call h5lexists_f(file_id, group, group_exists, error)
-
-    if (.not. group_exists) then
-      ! Create a group
-      call h5gcreate_f(file_id, group, group_id, error)
-    else
-      ! Open the existing group
-      call h5gopen_f(file_id, group, group_id, error)
-    end if
-
-    if (present(scalar_input)) then
-      ! Create a scalar dataspace
-      call h5screate_f(H5S_SCALAR_F, dspace_id, error)
-    else
-      ! Open dataspace
-      call h5screate_simple_f(space_rank,data_dims,dspace_id,error)
-   end if
-    dataset_location = group//"/"//key
-    ! Check if the dataset exists
-    call h5lexists_f(file_id, trim(dataset_location), dataset_exists, error)
-
-    if (.not. dataset_exists) then
-      ! Create dataset if it doesn't exist already
-      call h5dcreate_f(group_id,key,h5t_native_double,dspace_id,dset_id,error)
-    end if
-
-    if (present(array_input_1d)) then
-      ! Write to dataset
-      call h5dwrite_f(dset_id,h5t_native_double,array_input_1d,data_dims,error)
-    end if
-
-    if (present(array_input_2d)) then
-      ! Write to dataset
-      call h5dwrite_f(dset_id,h5t_native_double,array_input_2d,data_dims,error)
-    end if
-
-    if (present(array_input_3d)) then
-      ! Write to dataset
-      call h5dwrite_f(dset_id,h5t_native_double,array_input_3d,data_dims,error)
-    end if
-
-    ! Close dataset
-    call h5dclose_f(dset_id,error)
-
-    ! Close dataspace
-    call h5sclose_f(dspace_id, error)
-
-    ! Close the group
-    call h5gclose_f(group_id, error)
-
-    ! Close the file.
-    call h5fclose_f(file_id, error)
-
-    ! Close Fortran interface.
-    call h5close_f(error)
-
-  end subroutine hdf5_write_real
-
-  subroutine hdf5_write_int(filename,scalar_input,&
-                            array_input_1d,array_input_2d,array_input_3d,key,group)
-
-    character(len=*), intent(in) :: filename
-    integer (int64), allocatable, optional, intent(in) :: array_input_1d(:)
-    integer (int64), allocatable, optional, intent(in) :: array_input_2d(:,:)
-    integer (int64), allocatable, optional, intent(in) :: array_input_3d(:,:,:)
-    integer (int64), optional, intent(in) :: scalar_input
-    character(len=*), intent(in) :: key, group
-    character(len=20) :: dataset_location
-    integer(hsize_t),allocatable :: data_dims(:)
-    integer(hid_t) :: file_id, dspace_id, dset_id, group_id
-    integer (int32) :: space_rank
-    integer (int8) :: arguments_present
-    integer :: error
-    logical :: file_exists, dataset_exists, group_exists
-    arguments_present=0
-    if (present(scalar_input)) then
-      arguments_present = arguments_present + 1
-    end if
-
-    if (present(array_input_1d)) then
-       if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
-      end if
-      arguments_present = arguments_present + 1
-      allocate(data_dims(1))
-      data_dims(1) = size(array_input_1d,1)
-      space_rank = 1
-    end if
-
-    if (present(array_input_2d)) then
-      if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
-      end if
-      arguments_present = arguments_present + 1
-      allocate(data_dims(2))
-      data_dims(1) = size(array_input_2d,1)
-      data_dims(2) = size(array_input_2d,2)
-      space_rank = 2
-    end if
-
-    if (present(array_input_3d)) then
-      if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
-      end if
-      allocate(data_dims(3))
-      data_dims(1) = size(array_input_3d,1)
-      data_dims(2) = size(array_input_3d,2)
-      data_dims(3) = size(array_input_3d,3)
-      space_rank = 3
-    end if
-
-    ! Initialize Fortran interface.
-    call h5open_f(error)
-
-    inquire(file=trim(filename), exist=file_exists )
-
-    if (file_exists) then
-      ! Open an existing file.
-      call h5fopen_f(trim(filename), h5F_acc_rdwr_f, file_id, error)
-    else
-      ! Create file requested
-      call h5fcreate_f(trim(filename), h5f_acc_rdwr_f, file_id, error)
-    end if
-
-    ! Check if the group exists
-    call h5lexists_f(file_id, group, group_exists, error)
-
-    if (.not. group_exists) then
-      ! Create a group
-      call h5gcreate_f(file_id, group, group_id, error)
-    else
-      ! Open the existing group
-      call h5gopen_f(file_id, group, group_id, error)
-   end if
-
-    if (present(scalar_input)) then
-      ! Create a scalar dataspace
-      call h5screate_f(H5S_SCALAR_F, dspace_id, error)
-    else
-      ! Open dataspace
-      call h5screate_simple_f(space_rank,data_dims,dspace_id,error)
-    end if
-     dataset_location = group//"/"//key
-    ! Check if the dataset exists
-     call h5lexists_f(file_id, trim(dataset_location), dataset_exists, error)
-
-    if (.not. dataset_exists) then
-      ! Create dataset if it doesn't exist already
-      call h5dcreate_f(group_id,key,H5T_STD_I64LE,dspace_id,dset_id,error)
-    end if
-
-    if (present(array_input_1d)) then
-      ! Write to dataset
-      call h5dwrite_f(dset_id,H5T_STD_I64LE,array_input_1d,data_dims,error)
-    end if
-
-    if (present(array_input_2d)) then
-      ! Write to dataset
-      call h5dwrite_f(dset_id,H5T_STD_I64LE,array_input_2d,data_dims,error)
-    end if
-
-    if (present(array_input_3d)) then
-      ! Write to dataset
-       call h5dwrite_f(dset_id,H5T_STD_I64LE,array_input_3d,data_dims,error)
-    end if
-
-    ! Close dataset
-    call h5dclose_f(dset_id,error)
-
-    ! Close dataspace
-    call h5sclose_f(dspace_id, error)
-
-    ! Close the group
-    call h5gclose_f(group_id, error)
-
-    ! Close the file.
-    call h5fclose_f(file_id, error)
-
-    ! Close Fortran interface.
-    call h5close_f(error)
-
-  end subroutine hdf5_write_int
-
-      SUBROUTINE writeOutput1_hdf5
+      SUBROUTINE write_output_hdf5
        CHARACTER(len=150)  :: filename1
        INTEGER  :: k, i, j, g
        REAL (dp), allocatable :: u1(:,:,:), v1(:,:,:), w1(:,:,:)
        character (len=11) :: dummy_1
        character (len=5) ::dummy_2
 
-         IF((mod(ita,200_int64) ==0 .or. ita <= 2 ))then
-         !$acc serial
          do g=1,nblocks
             write(dummy_1,'(A6,I5.5)') 'block_',g
             write(dummy_2,'(I5.5)') ita
@@ -292,7 +38,7 @@ contains
             END DO
             END DO
             END DO
-            filename1="output_"//trim(dummy_2)//".h5"
+            filename1="out/output_"//trim(dummy_2)//".h5"
             call hdf5_write_real(filename=filename1,&
                                  array_input_3d=u1,key='u1',group=dummy_1)
             call hdf5_write_real(filename=filename1,&
@@ -323,12 +69,9 @@ contains
                                 array_input_3d=block(g)%cell_pr,key='cell_pr',group=dummy_1)
             deallocate(u1,v1,w1)
          end do
-         !$acc end serial
-        !$acc wait
-         ENDIF
-       END SUBROUTINE writeOutput1_hdf5
+       END SUBROUTINE write_output_hdf5
 #else
-      SUBROUTINE writeOutput1
+      SUBROUTINE write_output_ascii
        CHARACTER(len=150)  :: filename1
        INTEGER  :: k, i, j, g
        REAL (dp) :: u1, v1, w1
@@ -358,7 +101,7 @@ contains
         end do
         !$acc wait
          ENDIF
-      END SUBROUTINE writeOutput1
+      END SUBROUTINE write_output_ascii
 #endif
       SUBROUTINE writeResult
         INTEGER::  i, j, k,g

--- a/src/WriteOutput_corner1.f90
+++ b/src/WriteOutput_corner1.f90
@@ -1,5 +1,5 @@
 module biocfd_write_output_corner1
-  use, intrinsic :: iso_fortran_env, only: dp => real64, int8,int16,int32,int64
+  use, intrinsic :: iso_fortran_env, only: dp => real64, int64
   ! allow(use-all) - TODO: Aim to fix this in the future
   use global
 #if USE_HDF5 == 1

--- a/src/WriteOutput_corner1.f90
+++ b/src/WriteOutput_corner1.f90
@@ -25,6 +25,7 @@ contains
        character (len=11) :: dummy_1
        character (len=5) ::dummy_2
 
+         IF((mod(ita,200_int64) ==0 .or. ita <= 2 ))then
          do g=1,nblocks
             write(dummy_1,'(A6,I5.5)') 'block_',g
             write(dummy_2,'(I5.5)') ita

--- a/src/WriteOutput_corner1.f90
+++ b/src/WriteOutput_corner1.f90
@@ -72,6 +72,7 @@ contains
                                 array_input_3d=block(g)%cell_pr,key='cell_pr',group=dummy_1)
             deallocate(u1,v1,w1)
          end do
+        ENDIF
        END SUBROUTINE write_output_hdf5
 #else
       SUBROUTINE write_output_ascii

--- a/src/WriteOutput_corner1.f90
+++ b/src/WriteOutput_corner1.f90
@@ -1,14 +1,333 @@
 module biocfd_write_output_corner1
-  use, intrinsic :: iso_fortran_env, only: dp => real64, int64
+  use, intrinsic :: iso_fortran_env, only: dp => real64, int8,int16,int32,int64
   ! allow(use-all) - TODO: Aim to fix this in the future
   use global
+#if USE_HDF5 == 1
+  use hdf5
+#endif
   implicit none
 
   private
 
+#if USE_HDF5 == 1
+  public :: writeOutput1_hdf5, body_plot, writeresult
+#else
   public :: writeOutput1, body_plot, writeresult
+#endif
 
 contains
+
+#if USE_HDF5 == 1
+  subroutine hdf5_write_real(filename,scalar_input,&
+                             array_input_1d,array_input_2d,array_input_3d,key,group)
+
+    character(len=*), intent(in) :: filename
+    real (dp), allocatable, optional, intent(in) :: array_input_1d(:)
+    real (dp), allocatable, optional, intent(in) :: array_input_2d(:,:)
+    real (dp), allocatable, optional, intent(in) :: array_input_3d(:,:,:)
+    real (dp), optional, intent (in) :: scalar_input
+    character(len=*), intent(in) :: key, group
+    character(len=20) :: dataset_location
+    integer(hsize_t),allocatable :: data_dims(:)
+    integer(hid_t) :: file_id, dspace_id, dset_id, group_id
+    integer (int32) :: space_rank
+    integer (int8) ::arguments_present
+    integer :: error
+    logical :: file_exists, dataset_exists, group_exists
+    arguments_present=0
+    if (present(scalar_input)) then
+      arguments_present = arguments_present + 1
+    end if
+
+    if (present(array_input_1d)) then
+      if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      arguments_present = arguments_present + 1
+      allocate(data_dims(1))
+      data_dims(1) = size(array_input_1d,1)
+      space_rank = 1
+    end if
+
+    if (present(array_input_2d)) then
+      if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      arguments_present = arguments_present + 1
+      allocate(data_dims(2))
+      data_dims(1) = size(array_input_2d,1)
+      data_dims(2) = size(array_input_2d,2)
+      space_rank = 2
+    end if
+
+    if (present(array_input_3d)) then
+      if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      allocate(data_dims(3))
+      data_dims(1) = size(array_input_3d,1)
+      data_dims(2) = size(array_input_3d,2)
+      data_dims(3) = size(array_input_3d,3)
+      space_rank = 3
+    end if
+
+    ! Initialize Fortran interface.
+    call h5open_f(error)
+
+    inquire(file=trim(filename), exist=file_exists )
+
+    if (file_exists) then
+      ! Open an existing file.
+      call h5fopen_f(trim(filename), h5F_acc_rdwr_f, file_id, error)
+    else
+      ! Create file requested
+      call h5fcreate_f(trim(filename), h5f_acc_excl_f, file_id, error)
+    end if
+
+    ! Check if the group exists
+    call h5lexists_f(file_id, group, group_exists, error)
+
+    if (.not. group_exists) then
+      ! Create a group
+      call h5gcreate_f(file_id, group, group_id, error)
+    else
+      ! Open the existing group
+      call h5gopen_f(file_id, group, group_id, error)
+    end if
+
+    if (present(scalar_input)) then
+      ! Create a scalar dataspace
+      call h5screate_f(H5S_SCALAR_F, dspace_id, error)
+    else
+      ! Open dataspace
+      call h5screate_simple_f(space_rank,data_dims,dspace_id,error)
+   end if
+    dataset_location = group//"/"//key
+    ! Check if the dataset exists
+    call h5lexists_f(file_id, trim(dataset_location), dataset_exists, error)
+
+    if (.not. dataset_exists) then
+      ! Create dataset if it doesn't exist already
+      call h5dcreate_f(group_id,key,h5t_native_double,dspace_id,dset_id,error)
+    end if
+
+    if (present(array_input_1d)) then
+      ! Write to dataset
+      call h5dwrite_f(dset_id,h5t_native_double,array_input_1d,data_dims,error)
+    end if
+
+    if (present(array_input_2d)) then
+      ! Write to dataset
+      call h5dwrite_f(dset_id,h5t_native_double,array_input_2d,data_dims,error)
+    end if
+
+    if (present(array_input_3d)) then
+      ! Write to dataset
+      call h5dwrite_f(dset_id,h5t_native_double,array_input_3d,data_dims,error)
+    end if
+
+    ! Close dataset
+    call h5dclose_f(dset_id,error)
+
+    ! Close dataspace
+    call h5sclose_f(dspace_id, error)
+
+    ! Close the group
+    call h5gclose_f(group_id, error)
+
+    ! Close the file.
+    call h5fclose_f(file_id, error)
+
+    ! Close Fortran interface.
+    call h5close_f(error)
+
+  end subroutine hdf5_write_real
+
+  subroutine hdf5_write_int(filename,scalar_input,&
+                            array_input_1d,array_input_2d,array_input_3d,key,group)
+
+    character(len=*), intent(in) :: filename
+    integer (int64), allocatable, optional, intent(in) :: array_input_1d(:)
+    integer (int64), allocatable, optional, intent(in) :: array_input_2d(:,:)
+    integer (int64), allocatable, optional, intent(in) :: array_input_3d(:,:,:)
+    integer (int64), optional, intent(in) :: scalar_input
+    character(len=*), intent(in) :: key, group
+    character(len=20) :: dataset_location
+    integer(hsize_t),allocatable :: data_dims(:)
+    integer(hid_t) :: file_id, dspace_id, dset_id, group_id
+    integer (int32) :: space_rank
+    integer (int8) :: arguments_present
+    integer :: error
+    logical :: file_exists, dataset_exists, group_exists
+    arguments_present=0
+    if (present(scalar_input)) then
+      arguments_present = arguments_present + 1
+    end if
+
+    if (present(array_input_1d)) then
+       if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      arguments_present = arguments_present + 1
+      allocate(data_dims(1))
+      data_dims(1) = size(array_input_1d,1)
+      space_rank = 1
+    end if
+
+    if (present(array_input_2d)) then
+      if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      arguments_present = arguments_present + 1
+      allocate(data_dims(2))
+      data_dims(1) = size(array_input_2d,1)
+      data_dims(2) = size(array_input_2d,2)
+      space_rank = 2
+    end if
+
+    if (present(array_input_3d)) then
+      if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      allocate(data_dims(3))
+      data_dims(1) = size(array_input_3d,1)
+      data_dims(2) = size(array_input_3d,2)
+      data_dims(3) = size(array_input_3d,3)
+      space_rank = 3
+    end if
+
+    ! Initialize Fortran interface.
+    call h5open_f(error)
+
+    inquire(file=trim(filename), exist=file_exists )
+
+    if (file_exists) then
+      ! Open an existing file.
+      call h5fopen_f(trim(filename), h5F_acc_rdwr_f, file_id, error)
+    else
+      ! Create file requested
+      call h5fcreate_f(trim(filename), h5f_acc_rdwr_f, file_id, error)
+    end if
+
+    ! Check if the group exists
+    call h5lexists_f(file_id, group, group_exists, error)
+
+    if (.not. group_exists) then
+      ! Create a group
+      call h5gcreate_f(file_id, group, group_id, error)
+    else
+      ! Open the existing group
+      call h5gopen_f(file_id, group, group_id, error)
+   end if
+
+    if (present(scalar_input)) then
+      ! Create a scalar dataspace
+      call h5screate_f(H5S_SCALAR_F, dspace_id, error)
+    else
+      ! Open dataspace
+      call h5screate_simple_f(space_rank,data_dims,dspace_id,error)
+    end if
+     dataset_location = group//"/"//key
+    ! Check if the dataset exists
+     call h5lexists_f(file_id, trim(dataset_location), dataset_exists, error)
+
+    if (.not. dataset_exists) then
+      ! Create dataset if it doesn't exist already
+      call h5dcreate_f(group_id,key,H5T_NATIVE_INTEGER,dspace_id,dset_id,error)
+    end if
+
+    if (present(array_input_1d)) then
+      ! Write to dataset
+      call h5dwrite_f(dset_id,H5T_NATIVE_INTEGER,array_input_1d,data_dims,error)
+    end if
+
+    if (present(array_input_2d)) then
+      ! Write to dataset
+      call h5dwrite_f(dset_id,H5T_NATIVE_INTEGER,array_input_2d,data_dims,error)
+    end if
+
+    if (present(array_input_3d)) then
+      ! Write to dataset
+       call h5dwrite_f(dset_id,H5T_NATIVE_INTEGER,array_input_3d,data_dims,error)
+    end if
+
+    ! Close dataset
+    call h5dclose_f(dset_id,error)
+
+    ! Close dataspace
+    call h5sclose_f(dspace_id, error)
+
+    ! Close the group
+    call h5gclose_f(group_id, error)
+
+    ! Close the file.
+    call h5fclose_f(file_id, error)
+
+    ! Close Fortran interface.
+    call h5close_f(error)
+
+  end subroutine hdf5_write_int
+
+      SUBROUTINE writeOutput1_hdf5
+       CHARACTER(len=150)  :: filename1
+       INTEGER  :: k, i, j, g
+       REAL (dp), allocatable :: u1(:,:,:), v1(:,:,:), w1(:,:,:)
+       character (len=11) :: dummy_1
+       character (len=5) ::dummy_2
+
+         IF((mod(ita,200_int64) ==0 .or. ita <= 2 ))then
+         !$acc serial
+         do g=1,nblocks
+            write(dummy_1,'(A6,I5.5)') 'block_',g
+            write(dummy_2,'(I5.5)') ita
+            allocate(u1(2:block(g)%nz+1,2:block(g)%ny+1,2:block(g)%nx+1),&
+                     v1(2:block(g)%nz+1,2:block(g)%ny+1,2:block(g)%nx+1),&
+                     w1(2:block(g)%nz+1,2:block(g)%ny+1,2:block(g)%nx+1))
+            DO k = 2, block(g)%nz+1
+            DO j = 2, block(g)%ny+1
+            DO i = 2, block(g)%nx+1
+               u1(k,j,i) = 0.5_dp*(block(g)%u(i,j,k)+block(g)%u(i-1,j,k))
+               v1(k,j,i) = 0.5_dp*(block(g)%v(i,j,k)+block(g)%v(i,j-1,k))
+               w1(k,j,i) = 0.5_dp*(block(g)%w(i,j,k)+block(g)%w(i,j,k-1))
+            END DO
+            END DO
+            END DO
+            filename1="test_"//trim(dummy_2)//".h5"
+            call hdf5_write_real(filename=filename1,&
+                                 array_input_3d=u1,key='u1',group=dummy_1)
+            call hdf5_write_real(filename=filename1,&
+                                 array_input_3d=v1,key='v1',group=dummy_1)
+            call hdf5_write_real(filename=filename1,&
+                                 array_input_3d=w1,key='w1',group=dummy_1)
+            call hdf5_write_real(filename=filename1,&
+                                 array_input_1d=block(g)%xp,key='xp',group=dummy_1)
+            call hdf5_write_real(filename=filename1,&
+                                 array_input_1d=block(g)%yp,key='yp',group=dummy_1)
+            call hdf5_write_real(filename=filename1,&
+                                 array_input_1d=block(g)%zp,key='zp',group=dummy_1)
+            call hdf5_write_int(filename=filename1,&
+                                scalar_input=block(g)%nx,key='zonei',group=dummy_1)
+            call hdf5_write_int(filename=filename1,&
+                                scalar_input=block(g)%nx,key='zonej',group=dummy_1)
+            call hdf5_write_int(filename=filename1,&
+                                scalar_input=block(g)%nz,key='zonek',group=dummy_1)
+            call hdf5_write_real(filename=filename1,&
+                                 array_input_3d=block(g)%p,key='p',group=dummy_1)
+            call hdf5_write_real(filename=filename1,&
+                                 scalar_input=totime,key='totime',group=dummy_1)
+            call hdf5_write_int(filename=filename1,&
+                                array_input_3d=block(g)%cell,key='cell',group=dummy_1)
+            call hdf5_write_int(filename=filename1,&
+                                array_input_3d=block(g)%cell_n,key='cell_n',group=dummy_1)
+            call hdf5_write_int(filename=filename1,&
+                                array_input_3d=block(g)%cell_pr,key='cell_pr',group=dummy_1)
+            deallocate(u1,v1,w1)
+         end do
+         !$acc end serial
+        !$acc wait
+         ENDIF
+       END SUBROUTINE writeOutput1_hdf5
+#else
       SUBROUTINE writeOutput1
        CHARACTER(len=150)  :: filename1
        INTEGER  :: k, i, j, g
@@ -40,10 +359,10 @@ contains
         !$acc wait
          ENDIF
       END SUBROUTINE writeOutput1
-
+#endif
       SUBROUTINE writeResult
         INTEGER::  i, j, k,g
-       CHARACTER(len=70)  :: filename1
+        CHARACTER(len=70)  :: filename1
         IF(mod(ita,500_int64)==0)THEN
            Do g=1,nblocks
            WRITE(filename1,22)char_f,g,re,block(2)%dx

--- a/src/WriteOutput_corner1.f90
+++ b/src/WriteOutput_corner1.f90
@@ -292,7 +292,7 @@ contains
             END DO
             END DO
             END DO
-            filename1="test_"//trim(dummy_2)//".h5"
+            filename1="output_"//trim(dummy_2)//".h5"
             call hdf5_write_real(filename=filename1,&
                                  array_input_3d=u1,key='u1',group=dummy_1)
             call hdf5_write_real(filename=filename1,&

--- a/src/WriteOutput_corner1.f90
+++ b/src/WriteOutput_corner1.f90
@@ -29,15 +29,15 @@ contains
          do g=1,nblocks
             write(dummy_1,'(A6,I5.5)') 'block_',g
             write(dummy_2,'(I5.5)') ita
-            allocate(u1(2:block(g)%nz+1,2:block(g)%ny+1,2:block(g)%nx+1),&
-                     v1(2:block(g)%nz+1,2:block(g)%ny+1,2:block(g)%nx+1),&
-                     w1(2:block(g)%nz+1,2:block(g)%ny+1,2:block(g)%nx+1))
+            allocate(u1(2:block(g)%nx+1,2:block(g)%ny+1,2:block(g)%nz+1),&
+                     v1(2:block(g)%nx+1,2:block(g)%ny+1,2:block(g)%nz+1),&
+                     w1(2:block(g)%nx+1,2:block(g)%ny+1,2:block(g)%nz+1))
             DO k = 2, block(g)%nz+1
             DO j = 2, block(g)%ny+1
             DO i = 2, block(g)%nx+1
-               u1(k,j,i) = 0.5_dp*(block(g)%u(i,j,k)+block(g)%u(i-1,j,k))
-               v1(k,j,i) = 0.5_dp*(block(g)%v(i,j,k)+block(g)%v(i,j-1,k))
-               w1(k,j,i) = 0.5_dp*(block(g)%w(i,j,k)+block(g)%w(i,j,k-1))
+               u1(i,j,k) = 0.5_dp*(block(g)%u(i,j,k)+block(g)%u(i-1,j,k))
+               v1(i,j,k) = 0.5_dp*(block(g)%v(i,j,k)+block(g)%v(i,j-1,k))
+               w1(i,j,k) = 0.5_dp*(block(g)%w(i,j,k)+block(g)%w(i,j,k-1))
             END DO
             END DO
             END DO

--- a/src/hdf5_io.f90
+++ b/src/hdf5_io.f90
@@ -1,0 +1,271 @@
+module biocfd_hdf5_io
+  use, intrinsic :: iso_fortran_env, only: dp => real64, int8,int16,int32,int64
+  ! allow(use-all) - TODO: Aim to fix this in the future
+  use global
+#if USE_HDF5 == 1
+  use hdf5, only: hsize_t, hid_t, h5open_f, h5fopen_f, h5fcreate_f, h5lexists_f, &
+       h5gcreate_f, h5gopen_f, h5screate_f, h5screate_simple_f, h5dcreate_f, &
+       h5dwrite_f, h5dclose_f, h5sclose_f, h5gclose_f, h5fclose_f, h5close_f, &
+       h5F_acc_rdwr_f, H5S_SCALAR_F, H5T_STD_I64LE, h5f_acc_excl_f, h5t_native_double
+#endif
+  implicit none
+
+  private
+
+#if USE_HDF5 == 1
+  public :: hdf5_write_real, hdf5_write_int
+#endif
+contains
+
+#if USE_HDF5 == 1
+  subroutine hdf5_write_real(filename,scalar_input,&
+                             array_input_1d,array_input_2d,array_input_3d,key,group)
+
+    character(len=*), intent(in) :: filename
+    real (dp), allocatable, optional, intent(in) :: array_input_1d(:)
+    real (dp), allocatable, optional, intent(in) :: array_input_2d(:,:)
+    real (dp), allocatable, optional, intent(in) :: array_input_3d(:,:,:)
+    real (dp), optional, intent (in) :: scalar_input
+    character(len=*), intent(in) :: key, group
+    character(len=20) :: dataset_location
+    integer(hsize_t),allocatable :: data_dims(:)
+    integer(hid_t) :: file_id, dspace_id, dset_id, group_id
+    integer (int32) :: space_rank
+    integer (int8) ::arguments_present
+    integer :: error
+    logical :: file_exists, dataset_exists, group_exists
+    arguments_present=0
+    if (present(scalar_input)) then
+      arguments_present = arguments_present + 1
+    end if
+
+    if (present(array_input_1d)) then
+      if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      arguments_present = arguments_present + 1
+      allocate(data_dims(1))
+      data_dims(1) = size(array_input_1d,1)
+      space_rank = 1
+    end if
+
+    if (present(array_input_2d)) then
+      if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      arguments_present = arguments_present + 1
+      allocate(data_dims(2))
+      data_dims(1) = size(array_input_2d,1)
+      data_dims(2) = size(array_input_2d,2)
+      space_rank = 2
+    end if
+
+    if (present(array_input_3d)) then
+      if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      allocate(data_dims(3))
+      data_dims(1) = size(array_input_3d,1)
+      data_dims(2) = size(array_input_3d,2)
+      data_dims(3) = size(array_input_3d,3)
+      space_rank = 3
+    end if
+
+    ! Initialize Fortran interface.
+    call h5open_f(error)
+
+    inquire(file=trim(filename), exist=file_exists )
+
+    if (file_exists) then
+      ! Open an existing file.
+      call h5fopen_f(trim(filename), h5F_acc_rdwr_f, file_id, error)
+    else
+      ! Create file requested
+      call h5fcreate_f(trim(filename), h5f_acc_excl_f, file_id, error)
+    end if
+
+    ! Check if the group exists
+    call h5lexists_f(file_id, group, group_exists, error)
+
+    if (.not. group_exists) then
+      ! Create a group
+      call h5gcreate_f(file_id, group, group_id, error)
+    else
+      ! Open the existing group
+      call h5gopen_f(file_id, group, group_id, error)
+    end if
+
+    if (present(scalar_input)) then
+      ! Create a scalar dataspace
+      call h5screate_f(H5S_SCALAR_F, dspace_id, error)
+    else
+      ! Open dataspace
+      call h5screate_simple_f(space_rank,data_dims,dspace_id,error)
+   end if
+    dataset_location = group//"/"//key
+    ! Check if the dataset exists
+    call h5lexists_f(file_id, trim(dataset_location), dataset_exists, error)
+
+    if (.not. dataset_exists) then
+      ! Create dataset if it doesn't exist already
+      call h5dcreate_f(group_id,key,h5t_native_double,dspace_id,dset_id,error)
+    end if
+
+    if (present(array_input_1d)) then
+      ! Write to dataset
+      call h5dwrite_f(dset_id,h5t_native_double,array_input_1d,data_dims,error)
+    end if
+
+    if (present(array_input_2d)) then
+      ! Write to dataset
+      call h5dwrite_f(dset_id,h5t_native_double,array_input_2d,data_dims,error)
+    end if
+
+    if (present(array_input_3d)) then
+      ! Write to dataset
+      call h5dwrite_f(dset_id,h5t_native_double,array_input_3d,data_dims,error)
+    end if
+
+    ! Close dataset
+    call h5dclose_f(dset_id,error)
+
+    ! Close dataspace
+    call h5sclose_f(dspace_id, error)
+
+    ! Close the group
+    call h5gclose_f(group_id, error)
+
+    ! Close the file.
+    call h5fclose_f(file_id, error)
+
+    ! Close Fortran interface.
+    call h5close_f(error)
+
+  end subroutine hdf5_write_real
+
+  subroutine hdf5_write_int(filename,scalar_input,&
+                            array_input_1d,array_input_2d,array_input_3d,key,group)
+
+    character(len=*), intent(in) :: filename
+    integer (int64), allocatable, optional, intent(in) :: array_input_1d(:)
+    integer (int64), allocatable, optional, intent(in) :: array_input_2d(:,:)
+    integer (int64), allocatable, optional, intent(in) :: array_input_3d(:,:,:)
+    integer (int64), optional, intent(in) :: scalar_input
+    character(len=*), intent(in) :: key, group
+    character(len=20) :: dataset_location
+    integer(hsize_t),allocatable :: data_dims(:)
+    integer(hid_t) :: file_id, dspace_id, dset_id, group_id
+    integer (int32) :: space_rank
+    integer (int8) :: arguments_present
+    integer :: error
+    logical :: file_exists, dataset_exists, group_exists
+    arguments_present=0
+    if (present(scalar_input)) then
+      arguments_present = arguments_present + 1
+    end if
+
+    if (present(array_input_1d)) then
+       if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      arguments_present = arguments_present + 1
+      allocate(data_dims(1))
+      data_dims(1) = size(array_input_1d,1)
+      space_rank = 1
+    end if
+
+    if (present(array_input_2d)) then
+      if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      arguments_present = arguments_present + 1
+      allocate(data_dims(2))
+      data_dims(1) = size(array_input_2d,1)
+      data_dims(2) = size(array_input_2d,2)
+      space_rank = 2
+    end if
+
+    if (present(array_input_3d)) then
+      if(arguments_present /= 0 ) then
+        error stop 'More than one argument present hdf5_write'
+      end if
+      allocate(data_dims(3))
+      data_dims(1) = size(array_input_3d,1)
+      data_dims(2) = size(array_input_3d,2)
+      data_dims(3) = size(array_input_3d,3)
+      space_rank = 3
+    end if
+
+    ! Initialize Fortran interface.
+    call h5open_f(error)
+
+    inquire(file=trim(filename), exist=file_exists )
+
+    if (file_exists) then
+      ! Open an existing file.
+      call h5fopen_f(trim(filename), h5F_acc_rdwr_f, file_id, error)
+    else
+      ! Create file requested
+      call h5fcreate_f(trim(filename), h5f_acc_rdwr_f, file_id, error)
+    end if
+
+    ! Check if the group exists
+    call h5lexists_f(file_id, group, group_exists, error)
+
+    if (.not. group_exists) then
+      ! Create a group
+      call h5gcreate_f(file_id, group, group_id, error)
+    else
+      ! Open the existing group
+      call h5gopen_f(file_id, group, group_id, error)
+   end if
+
+    if (present(scalar_input)) then
+      ! Create a scalar dataspace
+      call h5screate_f(H5S_SCALAR_F, dspace_id, error)
+    else
+      ! Open dataspace
+      call h5screate_simple_f(space_rank,data_dims,dspace_id,error)
+    end if
+     dataset_location = group//"/"//key
+    ! Check if the dataset exists
+     call h5lexists_f(file_id, trim(dataset_location), dataset_exists, error)
+
+    if (.not. dataset_exists) then
+      ! Create dataset if it doesn't exist already
+      call h5dcreate_f(group_id,key,H5T_STD_I64LE,dspace_id,dset_id,error)
+    end if
+
+    if (present(array_input_1d)) then
+      ! Write to dataset
+      call h5dwrite_f(dset_id,H5T_STD_I64LE,array_input_1d,data_dims,error)
+    end if
+
+    if (present(array_input_2d)) then
+      ! Write to dataset
+      call h5dwrite_f(dset_id,H5T_STD_I64LE,array_input_2d,data_dims,error)
+    end if
+
+    if (present(array_input_3d)) then
+      ! Write to dataset
+       call h5dwrite_f(dset_id,H5T_STD_I64LE,array_input_3d,data_dims,error)
+    end if
+
+    ! Close dataset
+    call h5dclose_f(dset_id,error)
+
+    ! Close dataspace
+    call h5sclose_f(dspace_id, error)
+
+    ! Close the group
+    call h5gclose_f(group_id, error)
+
+    ! Close the file.
+    call h5fclose_f(file_id, error)
+
+    ! Close Fortran interface.
+    call h5close_f(error)
+
+  end subroutine hdf5_write_int
+#endif
+end module biocfd_hdf5_io

--- a/src/hdf5_io.f90
+++ b/src/hdf5_io.f90
@@ -1,3 +1,4 @@
+#if USE_HDF5 == 1
 module biocfd_hdf5_io
   use, intrinsic :: iso_fortran_env, only: dp => real64, int8,int16,int32,int64
   ! allow(use-all) - TODO: Aim to fix this in the future
@@ -263,3 +264,4 @@ contains
 
   end subroutine hdf5_write_int
 end module biocfd_hdf5_io
+#endif

--- a/src/hdf5_io.f90
+++ b/src/hdf5_io.f90
@@ -1,3 +1,6 @@
+! FPM resolves which modules need to be compiled before any
+! preprocessing so we need this guard here to make sure this file is
+! effectively empty
 #if USE_HDF5 == 1
 module biocfd_hdf5_io
   use, intrinsic :: iso_fortran_env, only: dp => real64, int8,int16,int32,int64

--- a/src/hdf5_io.f90
+++ b/src/hdf5_io.f90
@@ -2,22 +2,17 @@ module biocfd_hdf5_io
   use, intrinsic :: iso_fortran_env, only: dp => real64, int8,int16,int32,int64
   ! allow(use-all) - TODO: Aim to fix this in the future
   use global
-#if USE_HDF5 == 1
   use hdf5, only: hsize_t, hid_t, h5open_f, h5fopen_f, h5fcreate_f, h5lexists_f, &
        h5gcreate_f, h5gopen_f, h5screate_f, h5screate_simple_f, h5dcreate_f, &
        h5dwrite_f, h5dclose_f, h5sclose_f, h5gclose_f, h5fclose_f, h5close_f, &
        h5F_acc_rdwr_f, H5S_SCALAR_F, H5T_STD_I64LE, h5f_acc_excl_f, h5t_native_double
-#endif
   implicit none
 
   private
 
-#if USE_HDF5 == 1
   public :: hdf5_write_real, hdf5_write_int
-#endif
 contains
 
-#if USE_HDF5 == 1
   subroutine hdf5_write_real(filename,scalar_input,&
                              array_input_1d,array_input_2d,array_input_3d,key,group)
 
@@ -267,5 +262,4 @@ contains
     call h5close_f(error)
 
   end subroutine hdf5_write_int
-#endif
 end module biocfd_hdf5_io


### PR DESCRIPTION
Fixes https://github.com/BioFSILab/Bio-CFD/issues/109

This PR gives the user the option to output of writeOutput1 to a hdf5 file instead of an ascii file. You will need hdf5 installed regardless of whether you are making use of it or not. To build and run the code after this PR you will need fpm version 0.11 and above, since it needs the hdf5 metapackage provided by fpm. fpm makes use of pkg config to find hdf5, so you make need to define a package file yourself, and add the path to it, to your pkg_config_path environment variable. The default is USE_HDF5=0. To output to hdf5 you need to change USE_HDF5=1 in the fpm.toml file.