### PR TITLE
Remove unused xp1 and xpn1 (and y and z)

### DIFF
--- a/src/ReadInput.f90
+++ b/src/ReadInput.f90
@@ -167,10 +167,7 @@ module biocfd_read_input
                      block(i)%zw(block(i)%nz+3),&
                      block(i)%xp(block(i)%nx+2), &
                      block(i)%yp(block(i)%ny+2), &
-                     block(i)%zp(block(i)%nz+2),&
-                     block(i)%xp_dum(block(i)%nx+2), &
-                     block(i)%yp_dum(block(i)%ny+2), &
-                     block(i)%zp_dum(block(i)%nz+2))
+                     block(i)%zp(block(i)%nz+2))
 
           block(i)%cintp=3
             END DO

--- a/src/ReadInput.f90
+++ b/src/ReadInput.f90
@@ -172,12 +172,6 @@ module biocfd_read_input
                      block(i)%yp_dum(block(i)%ny+2), &
                      block(i)%zp_dum(block(i)%nz+2))
 
-          ALLOCATE ( block(i)%xp1(nx_var+2,ny_var+2,nz_var+2) )
-          ALLOCATE ( block(i)%yp1(nx_var+2,ny_var+2,nz_var+2) )
-          ALLOCATE ( block(i)%zp1(nx_var+2,ny_var+2,nz_var+2) )
-          ALLOCATE ( block(i)%xpn1(nx_var+2,ny_var+2,nz_var+2) )
-          ALLOCATE ( block(i)%ypn1(nx_var+2,ny_var+2,nz_var+2) )
-          ALLOCATE ( block(i)%zpn1(nx_var+2,ny_var+2,nz_var+2) )
           block(i)%cintp=3
             END DO
 
@@ -308,36 +302,6 @@ module biocfd_read_input
             block(g)%zp(i) = block(g)%zu(i)
           END DO
         ENDDO
-        DO g=1,nblocks
-
-        DO k=1,block(g)%nz+1
-        DO j=1,block(g)%ny+1
-        DO i=1,block(g)%nx+1
-
-        block(g)%xpn1(i,j,k)=block(g)%x1(i)
-        block(g)%ypn1(i,j,k)=block(g)%y1(j)
-        block(g)%zpn1(i,j,k)=block(g)%z1(k)
-
-
-        END DO
-        END DO
-        END DO
-        END DO
-
-        DO g=1,nblocks
-        DO k=2,block(g)%nz+1
-        DO j=2,block(g)%ny+1
-        DO i=2,block(g)%nx+1
-
-        block(g)%xp1(i,j,k)=block(g)%xp(i)
-        block(g)%yp1(i,j,k)=block(g)%yp(j)
-        block(g)%zp1(i,j,k)=block(g)%zp(k)
-
-
-        END DO
-        END DO
-        END DO
-        END DO
 
       END SUBROUTINE readInput
 

--- a/src/ReadInput.f90
+++ b/src/ReadInput.f90
@@ -11,7 +11,7 @@ module biocfd_read_input
   contains
 
       SUBROUTINE readInput
-       INTEGER (int64) :: i, j , k , g, nx_var, ny_var, nz_var
+       INTEGER (int64) :: i, g, nx_var, ny_var, nz_var
         CHARACTER(len=160)  :: filename1
        ! MB: Temporary variables added, to separate them out from type Blocks. Kept until
        !     not dependent on diff for checking code changes don't break code

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -1459,31 +1459,6 @@ block(g)%fluidCellCount = flcnt
            block(g)%zv(i) = block(g)%zu(i)
            block(g)%zp(i) = block(g)%zu(i)
         END DO
-        DO k=1,block(g)%nz+1
-        DO j=1,block(g)%ny+1
-        DO i=1,block(g)%nx+1
-
-        block(g)%xpn1(i,j,k)=block(g)%x1(i)
-        block(g)%ypn1(i,j,k)=block(g)%y1(j)
-        block(g)%zpn1(i,j,k)=block(g)%z1(k)
-
-
-        END DO
-        END DO
-        END DO
-
-        DO k=2,block(g)%nz+1
-        DO j=2,block(g)%ny+1
-        DO i=2,block(g)%nx+1
-
-        block(g)%xp1(i,j,k)=block(g)%xp(i)
-        block(g)%yp1(i,j,k)=block(g)%yp(j)
-        block(g)%zp1(i,j,k)=block(g)%zp(k)
-
-
-        END DO
-        END DO
-        END DO
 
         ENDIF
 

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -1391,9 +1391,6 @@ block(g)%fluidCellCount = flcnt
         ENDDO
         ENDDO
         ENDDO
-        block(b_blk_no)%xp_dum=block(b_blk_no)%xp
-        block(b_blk_no)%yp_dum=block(b_blk_no)%yp
-        block(b_blk_no)%zp_dum=block(b_blk_no)%zp
         endif
 
         ENDDO

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -104,7 +104,6 @@ MODULE global
        INTEGER (int64) :: cpy_z_start, cpy_z_end
        REAL (dp) :: theta, thetaDot, thetaDDot, piv_x,piv_y, piv_z
        REAL (dp) :: alphaDot, alphaDDot, thetaDot1, thetaDDot1, thetaDot2, thetaDDot2
-       REAL (dp), ALLOCATABLE, DIMENSION (:) :: xp_dum, yp_dum, zp_dum
 
 
        end type Blocks

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -59,9 +59,6 @@ MODULE global
                                                       ufl,vfl,wfl,  &
                                                       resi_u, resi_v, resi_w
 
-        REAL(sp) , ALLOCATABLE, DIMENSION (:, :, :) :: xp1, yp1, zp1
-        REAL(sp) , ALLOCATABLE, DIMENSION (:, :, :) :: xpn1, ypn1, zpn1
-
         INTEGER (int64), ALLOCATABLE, DIMENSION (:, :) :: fluidIndexPtr, redCellIndexPtr, &
                                                           blackCellIndexPtr, nodeId
         INTEGER(int64) :: ibCellCount, solidCellCount, fluidCellCount, redCellCount, &


### PR DESCRIPTION
These variables are only ever set and never read

```
❯ grep -Eiw ".pn?1" src/* app/main.f90
src/modGlobal.f90:        REAL(sp) , ALLOCATABLE, DIMENSION (:, :, :) :: xp1, yp1, zp1
src/modGlobal.f90:        REAL(sp) , ALLOCATABLE, DIMENSION (:, :, :) :: xpn1, ypn1, zpn1
src/ReadInput.f90:          ALLOCATE ( block(i)%xp1(nx_var+2,ny_var+2,nz_var+2) )
src/ReadInput.f90:          ALLOCATE ( block(i)%yp1(nx_var+2,ny_var+2,nz_var+2) )
src/ReadInput.f90:          ALLOCATE ( block(i)%zp1(nx_var+2,ny_var+2,nz_var+2) )
src/ReadInput.f90:          ALLOCATE ( block(i)%xpn1(nx_var+2,ny_var+2,nz_var+2) )
src/ReadInput.f90:          ALLOCATE ( block(i)%ypn1(nx_var+2,ny_var+2,nz_var+2) )
src/ReadInput.f90:          ALLOCATE ( block(i)%zpn1(nx_var+2,ny_var+2,nz_var+2) )
src/ReadInput.f90:        block(g)%xpn1(i,j,k)=block(g)%x1(i)
src/ReadInput.f90:        block(g)%ypn1(i,j,k)=block(g)%y1(j)
src/ReadInput.f90:        block(g)%zpn1(i,j,k)=block(g)%z1(k)
src/ReadInput.f90:        block(g)%xp1(i,j,k)=block(g)%xp(i)
src/ReadInput.f90:        block(g)%yp1(i,j,k)=block(g)%yp(j)
src/ReadInput.f90:        block(g)%zp1(i,j,k)=block(g)%zp(k)
src/Search.f90:        block(g)%xpn1(i,j,k)=block(g)%x1(i)
src/Search.f90:        block(g)%ypn1(i,j,k)=block(g)%y1(j)
src/Search.f90:        block(g)%zpn1(i,j,k)=block(g)%z1(k)
src/Search.f90:        block(g)%xp1(i,j,k)=block(g)%xp(i)
src/Search.f90:        block(g)%yp1(i,j,k)=block(g)%yp(j)
src/Search.f90:        block(g)%zp1(i,j,k)=block(g)%zp(k)
```
```
❯ grep -Eiw "[xyz]p_dum" src/* app/main.f90
src/modGlobal.f90:       REAL (dp), ALLOCATABLE, DIMENSION (:) :: xp_dum, yp_dum, zp_dum
src/ReadInput.f90:                     block(i)%xp_dum(block(i)%nx+2), &
src/ReadInput.f90:                     block(i)%yp_dum(block(i)%ny+2), &
src/ReadInput.f90:                     block(i)%zp_dum(block(i)%nz+2))
src/Search.f90:        block(b_blk_no)%xp_dum=block(b_blk_no)%xp
src/Search.f90:        block(b_blk_no)%yp_dum=block(b_blk_no)%yp
src/Search.f90:        block(b_blk_no)%zp_dum=block(b_blk_no)%zp
```