### PR TITLE
Remove unused alpha3, beta3 and gamma3

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -81,7 +81,7 @@
         CALL body_plot
         DO g=blk_start, nblocks
            DEALLOCATE(block(g)%xcent, block(g)%ycent, block(g)%zcent,block(g)%cosAlpha, &
-                block(g)%cosBeta, block(g)%cosGamma,block(g)%alpha3,block(g)%beta3, block(g)%gamma3)
+                block(g)%cosBeta, block(g)%cosGamma)
             block(g)%blk_mv_tag=0.
         END DO
         print *,10

--- a/src/Search.f90
+++ b/src/Search.f90
@@ -244,9 +244,7 @@ module biocfd_search
         ALLOCATE (block(g)%xcent(block(g)%ibElems), block(g)%ycent(block(g)%ibElems), &
                   block(g)%zcent(block(g)%ibElems), &
                   block(g)%cosAlpha(block(g)%ibElems), block(g)%cosBeta(block(g)%ibElems), &
-                  block(g)%cosGamma(block(g)%ibElems), &
-                  block(g)%alpha3(block(g)%ibElems), block(g)%beta3(block(g)%ibElems), &
-                  block(g)%gamma3(block(g)%ibElems))
+                  block(g)%cosGamma(block(g)%ibElems))
 
         !compute centroid and direction cosines
        !$acc parallel loop gang vector default(present) private (var_xcent, var_ycent, var_zcent,p1x, p1y, p1z, p2x, p2y, p2z, p3x, p3y, p3z, lenEL)  firstprivate (inor)
@@ -275,10 +273,6 @@ module biocfd_search
            block(g)%cosAlpha(n) = (p2y-p1y)*(p3z-p1z)-(p3y-p1y)*(p2z-p1z)
            block(g)%cosBeta(n)  = (p2z-p1z)*(p3x-p1x)-(p3z-p1z)*(p2x-p1x)
            block(g)%cosGamma(n) = (p2x-p1x)*(p3y-p1y)-(p3x-p1x)*(p2y-p1y)
-
-           block(g)%alpha3(n) = block(g)%cosAlpha(n)
-           block(g)%beta3(n)  = block(g)%cosBeta(n)
-           block(g)%gamma3(n) = block(g)%cosGamma(n)
 
            lenEL = dsqrt(block(g)%cosAlpha(n)**2 + block(g)%cosBeta(n)**2 + block(g)%cosGamma(n)**2)   !length of element
 

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -76,8 +76,8 @@ MODULE global
 
        INTEGER (int64), ALLOCATABLE, DIMENSION (:) :: nelp, nelu1, nelu2, nelv1, nelv2, nelw1, nelw2
        REAL (dp), ALLOCATABLE, DIMENSION (:) :: xcent, ycent, zcent, &
-                                                cosAlpha, cosBeta, cosGamma, alpha3, beta3, &
-                                                gamma3, pNormDis, u1NormDis, u2NormDis , &
+                                                cosAlpha, cosBeta, cosGamma, &
+                                                pNormDis, u1NormDis, u2NormDis , &
                                                 v1NormDis, v2NormDis, w1NormDis, w2NormDis, &
                                                 p_ghost, pt_ghost, u2_ghost, u2t_ghost, &
                                                 v2_ghost, v2t_ghost, w2_ghost, &


### PR DESCRIPTION
These 3 variables are set to be equal to cosAlpha, cosBeta and cosGamma, but never used, so this PR removes them.