### PR TITLE
Comment out HDF5 dependency

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,7 @@
 name = "Bio-CFD"
-dependencies.hdf5 = "*"
+# To use HDF5 uncomment the dependencies.hdf5 line below and set
+# USE_HDF5=1
+# dependencies.hdf5 = "*"
 version = "0.1.0"
 [build]
 auto-executables = true


### PR DESCRIPTION
So that we can build/run without having HDF5 available. I've tested this on Baskerville and it works.