### PR TITLE
Use a function in FineInterp_bound

### DIFF
--- a/src/FineInterp_bound.f90
+++ b/src/FineInterp_bound.f90
@@ -48,6 +48,9 @@ SUBROUTINE fineUpdate_bd
           end if
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!ppppppp!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        !$acc parallel loop collapse(3) private(varx1, varx2, vary1, vary2, varz1, varz2) &
+        !$acc private(loc_x, loc_y, loc_z, bl_interp_ans) &
+        !$acc firstprivate(a_blk_no, b_blk_no)
         DO k=1, intfr(g)%counterzp, steps(3)
         DO j=1, intfr(g)%counteryp, steps(2)
         DO i=1, intfr(g)%counterxp, steps(1)
@@ -94,12 +97,6 @@ SUBROUTINE fineUpdate_bd
         end subroutine fineUpdate_pc_bd
 
         SUBROUTINE fineUpdate_newv_bd
-        REAL (dp) :: bl_intp_valx,bl_intp_valy,bl_intp_x1,bl_intp_x2,bl_intp_y1,bl_intp_y2,&
-             bl_intp_f1,bl_intp_f2,bl_intp_f3,bl_intp_f4
-        REAL (dp) :: bl_intp_valz,bl_intp_z1,bl_intp_z2
-        REAL (dp) :: bl_intp_deno, bl_intp_num, bl_intp_xtx, bl_intp_xxo, bl_intp_yty, &
-             bl_intp_yyo, bl_intp_first_term, bl_intp_second_term
-        REAL (dp) :: bl_interp_ans, bl_interp_ans1, bl_interp_ans2
 
         INTEGER(int64) :: i,j,k, varx1,varx2, vary1, vary2, tar_x, tar_y, loc_x, &
              loc_y,g, a_blk_no, b_blk_no
@@ -127,6 +124,9 @@ SUBROUTINE fineUpdate_bd
                steps(3) = intfr(g)%counterzu-1
           end if
 
+        !$acc parallel loop collapse(3) private(varx1, varx2, vary1, vary2, varz1, varz2) &
+        !$acc private(loc_x, loc_y, loc_z) &
+        !$acc firstprivate(a_blk_no, b_blk_no)
         DO k=1, intfr(g)%counterzu, steps(3)
         DO j=1, intfr(g)%counteryu, steps(2)
         DO i=1, intfr(g)%counterxu, steps(1)
@@ -144,52 +144,25 @@ SUBROUTINE fineUpdate_bd
         loc_y=intfr(g)%uy_interface_det(1,j)
         loc_z=intfr(g)%uz_interface_det(1,k)
 
+        !$acc loop collapse(3) seq
         DO tar_z=varz1,varz2
         DO tar_y=vary1,vary2
         DO tar_x=varx1,varx2
 
-                bl_intp_valx=block(b_blk_no)%xu(tar_x)
-                bl_intp_valy=block(b_blk_no)%yu(tar_y)
-                bl_intp_valz=block(b_blk_no)%zu(tar_z)
-                bl_intp_x1=block(a_blk_no)%xu(loc_x-1)
-                bl_intp_x2=block(a_blk_no)%xu(loc_x+1)
-                bl_intp_y1=block(a_blk_no)%yu(loc_y-1)
-                bl_intp_y2=block(a_blk_no)%yu(loc_y+1)
-                bl_intp_z1=block(a_blk_no)%zu(loc_z-1)
-                bl_intp_z2=block(a_blk_no)%zu(loc_z+1)
-                bl_intp_f1=block(a_blk_no)%ut(loc_x-2,loc_y-1,loc_z-1)
-                bl_intp_f2=block(a_blk_no)%ut(loc_x,loc_y-1,loc_z-1)
-                bl_intp_f3=block(a_blk_no)%ut(loc_x,loc_y+1,loc_z-1)
-                bl_intp_f4=block(a_blk_no)%ut(loc_x-2,loc_y+1,loc_z-1)
+          block(b_blk_no)%ut(tar_x-1,tar_y,tar_z) = trilinear_interpolation(&
+               block(b_blk_no)%xu(tar_x), block(b_blk_no)%yu(tar_y), block(b_blk_no)%zu(tar_z), &
+               loc_x, loc_y, loc_z, block(a_blk_no)%xu, block(a_blk_no)%yu, block(a_blk_no)%zu, &
+               1, block(a_blk_no)%ut &
+          )
 
-                bl_intp_deno= (bl_intp_x2-bl_intp_x1) * (bl_intp_y2-bl_intp_y1)
-                bl_intp_xtx= (bl_intp_x2 -bl_intp_valx)
-                bl_intp_xxo=(bl_intp_valx-bl_intp_x1)
-                bl_intp_yty=(bl_intp_y2-bl_intp_valy)
-                bl_intp_yyo=(bl_intp_valy-bl_intp_y1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-
-                bl_interp_ans1=(bl_intp_num/bl_intp_deno)
-                bl_intp_f1=block(a_blk_no)%ut(loc_x-2,loc_y-1,loc_z+1)
-                bl_intp_f2=block(a_blk_no)%ut(loc_x,loc_y-1,loc_z+1)
-                bl_intp_f3=block(a_blk_no)%ut(loc_x,loc_y+1,loc_z+1)
-                bl_intp_f4=block(a_blk_no)%ut(loc_x-2,loc_y+1,loc_z+1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-                bl_interp_ans2=(bl_intp_num/bl_intp_deno)
-                bl_interp_ans= bl_interp_ans1 + ((bl_intp_valz-bl_intp_z1)*((bl_interp_ans2 - &
-                     bl_interp_ans1)/(bl_intp_z2 - bl_intp_z1)))
-                block(b_blk_no)%ut(tar_x-1,tar_y,tar_z)=bl_interp_ans
-                ENDDO
-                ENDDO
-                ENDDO
+          ENDDO
+          ENDDO
+          ENDDO
 
         ENDDO
         ENDDO
         ENDDO
+        !$acc end parallel loop
 
      end do  ! axes
 
@@ -210,6 +183,9 @@ SUBROUTINE fineUpdate_bd
              steps(3) = intfr(g)%counterzv-1
         end if
 
+        !$acc parallel loop collapse(3) private(varx1, varx2, vary1, vary2, varz1, varz2) &
+        !$acc private(loc_x, loc_y, loc_z) &
+        !$acc firstprivate(a_blk_no, b_blk_no)
         DO k=1, intfr(g)%counterzv, steps(3)
         DO j=1, intfr(g)%counteryv, steps(2)
         DO i=1, intfr(g)%counterxv, steps(1)
@@ -225,52 +201,25 @@ SUBROUTINE fineUpdate_bd
         loc_y=intfr(g)%vy_interface_det(1,j)
         loc_z=intfr(g)%vz_interface_det(1,k)
 
+        !$acc loop collapse(3) seq
         DO tar_z=varz1,varz2
         DO tar_y=vary1,vary2
         DO tar_x=varx1,varx2
 
-                bl_intp_valx=block(b_blk_no)%xv(tar_x)
-                bl_intp_valy=block(b_blk_no)%yv(tar_y)
-                bl_intp_valz=block(b_blk_no)%zv(tar_z)
-                bl_intp_x1=block(a_blk_no)%xv(loc_x-1)
-                bl_intp_x2=block(a_blk_no)%xv(loc_x+1)
-                bl_intp_y1=block(a_blk_no)%yv(loc_y-1)
-                bl_intp_y2=block(a_blk_no)%yv(loc_y+1)
-                bl_intp_z1=block(a_blk_no)%zv(loc_z-1)
-                bl_intp_z2=block(a_blk_no)%zv(loc_z+1)
-                bl_intp_f1=block(a_blk_no)%vt(loc_x-1,loc_y-2,loc_z-1)
-                bl_intp_f2=block(a_blk_no)%vt(loc_x+1,loc_y-2,loc_z-1)
-                bl_intp_f3=block(a_blk_no)%vt(loc_x+1,loc_y  ,loc_z-1)
-                bl_intp_f4=block(a_blk_no)%vt(loc_x-1,loc_y  ,loc_z-1)
+          block(b_blk_no)%vt(tar_x,tar_y-1,tar_z) = trilinear_interpolation(&
+               block(b_blk_no)%xv(tar_x), block(b_blk_no)%yv(tar_y), block(b_blk_no)%zv(tar_z), &
+               loc_x, loc_y, loc_z, block(a_blk_no)%xv, block(a_blk_no)%yv, block(a_blk_no)%zv, &
+               2, block(a_blk_no)%vt &
+          )
 
-                bl_intp_deno= (bl_intp_x2-bl_intp_x1) * (bl_intp_y2-bl_intp_y1)
-                bl_intp_xtx= (bl_intp_x2 -bl_intp_valx)
-                bl_intp_xxo=(bl_intp_valx-bl_intp_x1)
-                bl_intp_yty=(bl_intp_y2-bl_intp_valy)
-                bl_intp_yyo=(bl_intp_valy-bl_intp_y1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-
-                bl_interp_ans1=(bl_intp_num/bl_intp_deno)
-                bl_intp_f1=block(a_blk_no)%vt(loc_x-1,loc_y-2,loc_z+1)
-                bl_intp_f2=block(a_blk_no)%vt(loc_x+1,loc_y-2,loc_z+1)
-                bl_intp_f3=block(a_blk_no)%vt(loc_x+1,loc_y  ,loc_z+1)
-                bl_intp_f4=block(a_blk_no)%vt(loc_x-1,loc_y  ,loc_z+1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-                bl_interp_ans2=(bl_intp_num/bl_intp_deno)
-                bl_interp_ans= bl_interp_ans1 + ((bl_intp_valz-bl_intp_z1)*((bl_interp_ans2 - &
-                     bl_interp_ans1)/(bl_intp_z2 - bl_intp_z1)))
-                block(b_blk_no)%vt(tar_x,tar_y-1,tar_z)=bl_interp_ans
-                ENDDO
-                ENDDO
-                ENDDO
+          ENDDO
+          ENDDO
+          ENDDO
 
         ENDDO
         ENDDO
         ENDDO
+        !$acc end parallel loop
 
      end do  ! axes
 
@@ -290,6 +239,9 @@ SUBROUTINE fineUpdate_bd
              steps(3) = intfr(g)%counterzw-1
         end if
 
+        !$acc parallel loop collapse(3) private(varx1, varx2, vary1, vary2, varz1, varz2) &
+        !$acc private(loc_x, loc_y, loc_z) &
+        !$acc firstprivate(a_blk_no, b_blk_no)
         DO k=1, intfr(g)%counterzw, steps(3)
         DO j=1, intfr(g)%counteryw, steps(2)
         DO i=1, intfr(g)%counterxw, steps(1)
@@ -305,52 +257,25 @@ SUBROUTINE fineUpdate_bd
         loc_y=intfr(g)%wy_interface_det(1,j)
         loc_z=intfr(g)%wz_interface_det(1,k)
 
+        !$acc loop collapse(3) seq
         DO tar_z=varz1,varz2
         DO tar_y=vary1,vary2
         DO tar_x=varx1,varx2
 
-                bl_intp_valx=block(b_blk_no)%xw(tar_x)
-                bl_intp_valy=block(b_blk_no)%yw(tar_y)
-                bl_intp_valz=block(b_blk_no)%zw(tar_z)
-                bl_intp_x1=block(a_blk_no)%xw(loc_x-1)
-                bl_intp_x2=block(a_blk_no)%xw(loc_x+1)
-                bl_intp_y1=block(a_blk_no)%yw(loc_y-1)
-                bl_intp_y2=block(a_blk_no)%yw(loc_y+1)
-                bl_intp_z1=block(a_blk_no)%zw(loc_z-1)
-                bl_intp_z2=block(a_blk_no)%zw(loc_z+1)
-                bl_intp_f1=block(a_blk_no)%wt(loc_x-1,loc_y-1,loc_z-2)
-                bl_intp_f2=block(a_blk_no)%wt(loc_x+1,loc_y-1,loc_z-2)
-                bl_intp_f3=block(a_blk_no)%wt(loc_x+1,loc_y+1,loc_z-2)
-                bl_intp_f4=block(a_blk_no)%wt(loc_x-1,loc_y+1,loc_z-2)
+          block(b_blk_no)%wt(tar_x,tar_y,tar_z-1) = trilinear_interpolation(&
+               block(b_blk_no)%xw(tar_x), block(b_blk_no)%yw(tar_y), block(b_blk_no)%zw(tar_z), &
+               loc_x, loc_y, loc_z, block(a_blk_no)%xw, block(a_blk_no)%yw, block(a_blk_no)%zw, &
+               3, block(a_blk_no)%wt &
+          )
 
-                bl_intp_deno= (bl_intp_x2-bl_intp_x1) * (bl_intp_y2-bl_intp_y1)
-                bl_intp_xtx= (bl_intp_x2 -bl_intp_valx)
-                bl_intp_xxo=(bl_intp_valx-bl_intp_x1)
-                bl_intp_yty=(bl_intp_y2-bl_intp_valy)
-                bl_intp_yyo=(bl_intp_valy-bl_intp_y1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-
-                bl_interp_ans1=(bl_intp_num/bl_intp_deno)
-                bl_intp_f1=block(a_blk_no)%wt(loc_x-1,loc_y-1,loc_z)
-                bl_intp_f2=block(a_blk_no)%wt(loc_x+1,loc_y-1,loc_z)
-                bl_intp_f3=block(a_blk_no)%wt(loc_x+1,loc_y+1,loc_z)
-                bl_intp_f4=block(a_blk_no)%wt(loc_x-1,loc_y+1,loc_z)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-                bl_interp_ans2=(bl_intp_num/bl_intp_deno)
-                bl_interp_ans= bl_interp_ans1 + ((bl_intp_valz-bl_intp_z1)*((bl_interp_ans2 - &
-                     bl_interp_ans1)/(bl_intp_z2 - bl_intp_z1)))
-                block(b_blk_no)%wt(tar_x,tar_y,tar_z-1)=bl_interp_ans
-                ENDDO
-                ENDDO
-                ENDDO
+          ENDDO
+          ENDDO
+          ENDDO
 
         ENDDO
         ENDDO
         ENDDO
+        !$acc end parallel loop
 
      end do  ! axes
 

--- a/src/FineInterp_bound.f90
+++ b/src/FineInterp_bound.f90
@@ -71,11 +71,11 @@ SUBROUTINE fineUpdate_bd
           DO tar_y=vary1,vary2
             DO tar_x=varx1,varx2
 
-                bl_interp_ans = trilinear_interpolation(&
-                block(b_blk_no)%xp(tar_x), block(b_blk_no)%yp(tar_y), block(b_blk_no)%zp(tar_z), &
-                loc_x, loc_y, loc_z, block(a_blk_no)%xp, block(a_blk_no)%yp, block(a_blk_no)%zp, &
-                0, block(a_blk_no)%pc &
-                )
+               bl_interp_ans = trilinear_interpolation(&
+                 block(b_blk_no)%xp(tar_x), block(b_blk_no)%yp(tar_y), block(b_blk_no)%zp(tar_z), &
+                 loc_x, loc_y, loc_z, block(a_blk_no)%xp, block(a_blk_no)%yp, block(a_blk_no)%zp, &
+                 0, block(a_blk_no)%pc &
+               )
 
                 block(b_blk_no)%pc(tar_x, tar_y, tar_z) = bl_interp_ans
                 block(b_blk_no)%pco(tar_x, tar_y, tar_z) = bl_interp_ans
@@ -391,7 +391,7 @@ SUBROUTINE fineUpdate_bd
         DO tar_y=vary1,vary2
         DO tar_x=varx1,varx2
 
-               block(b_blk_no)%u(tar_x-1,tar_y,tar_z) = trilinear_interpolation(&
+          block(b_blk_no)%u(tar_x-1,tar_y,tar_z) = trilinear_interpolation(&
                block(b_blk_no)%xu(tar_x), block(b_blk_no)%yu(tar_y), block(b_blk_no)%zu(tar_z), &
                loc_x, loc_y, loc_z, block(a_blk_no)%xu, block(a_blk_no)%yu, block(a_blk_no)%zu, &
                1, block(a_blk_no)%u &
@@ -446,7 +446,7 @@ SUBROUTINE fineUpdate_bd
         DO tar_y=vary1,vary2
         DO tar_x=varx1,varx2
 
-                 block(b_blk_no)%v(tar_x,tar_y-1,tar_z) = trilinear_interpolation(&
+          block(b_blk_no)%v(tar_x,tar_y-1,tar_z) = trilinear_interpolation(&
                block(b_blk_no)%xv(tar_x), block(b_blk_no)%yv(tar_y), block(b_blk_no)%zv(tar_z), &
                loc_x, loc_y, loc_z, block(a_blk_no)%xv, block(a_blk_no)%yv, block(a_blk_no)%zv, &
                2, block(a_blk_no)%v &

--- a/src/FineInterp_bound.f90
+++ b/src/FineInterp_bound.f90
@@ -1,6 +1,8 @@
 module biocfd_fine_interp_bound
   use, intrinsic :: iso_fortran_env, only: dp => real64, int64
   use global, only : block, intfr, intflines
+  use biocfd_interpolation, only: bilinear_interpolation, linear_interpolation
+
   implicit none
 
   private
@@ -18,13 +20,8 @@ SUBROUTINE fineUpdate_bd
       end subroutine fineUpdate_bd
 
         SUBROUTINE fineUpdate_pc_bd
-        REAL (dp) :: bl_intp_valx,bl_intp_valy,bl_intp_x1,bl_intp_x2,bl_intp_y1,bl_intp_y2,&
-             bl_intp_f1,bl_intp_f2,bl_intp_f3,bl_intp_f4
-        REAL (dp) :: bl_intp_valz,bl_intp_z1,bl_intp_z2
-        REAL (dp) :: bl_intp_deno, bl_intp_num, bl_intp_xtx, bl_intp_xxo, bl_intp_yty, &
-             bl_intp_yyo, bl_intp_first_term, bl_intp_second_term
-        REAL (dp) :: bl_interp_ans, bl_interp_ans1, bl_interp_ans2
 
+        REAL (dp) :: bl_interp_ans
         INTEGER(int64) :: i,j,k, varx1,varx2, vary1, vary2, tar_x, tar_y, loc_x, &
              loc_y,g, a_blk_no, b_blk_no
         INTEGER(int64) :: varz1,varz2, tar_z, loc_z
@@ -66,56 +63,31 @@ SUBROUTINE fineUpdate_bd
         loc_y=intfr(g)%py_interface_det(1,j)
         loc_z=intfr(g)%pz_interface_det(1,k)
 
+        !$acc loop collapse(3) seq
         DO tar_z=varz1,varz2
-        DO tar_y=vary1,vary2
-        DO tar_x=varx1,varx2
+          DO tar_y=vary1,vary2
+            DO tar_x=varx1,varx2
 
-                bl_intp_valx=block(b_blk_no)%xp(tar_x)
-                bl_intp_valy=block(b_blk_no)%yp(tar_y)
-                bl_intp_valz=block(b_blk_no)%zp(tar_z)
-                bl_intp_x1=block(a_blk_no)%xp(loc_x-1)
-                bl_intp_x2=block(a_blk_no)%xp(loc_x+1)
-                bl_intp_y1=block(a_blk_no)%yp(loc_y-1)
-                bl_intp_y2=block(a_blk_no)%yp(loc_y+1)
-                bl_intp_z1=block(a_blk_no)%zp(loc_z-1)
-                bl_intp_z2=block(a_blk_no)%zp(loc_z+1)
-                bl_intp_f1=block(a_blk_no)%pc(loc_x-1,loc_y-1,loc_z-1)
-                bl_intp_f2=block(a_blk_no)%pc(loc_x+1,loc_y-1,loc_z-1)
-                bl_intp_f3=block(a_blk_no)%pc(loc_x+1,loc_y+1,loc_z-1)
-                bl_intp_f4=block(a_blk_no)%pc(loc_x-1,loc_y+1,loc_z-1)
+                bl_interp_ans = trilinear_interpolation(&
+                block(b_blk_no)%xp(tar_x), block(b_blk_no)%yp(tar_y), block(b_blk_no)%zp(tar_z), &
+                loc_x, loc_y, loc_z, block(a_blk_no)%xp, block(a_blk_no)%yp, block(a_blk_no)%zp, &
+                0, block(a_blk_no)%pc &
+                )
 
-                bl_intp_deno= (bl_intp_x2-bl_intp_x1) * (bl_intp_y2-bl_intp_y1)
-                bl_intp_xtx= (bl_intp_x2 -bl_intp_valx)
-                bl_intp_xxo=(bl_intp_valx-bl_intp_x1)
-                bl_intp_yty=(bl_intp_y2-bl_intp_valy)
-                bl_intp_yyo=(bl_intp_valy-bl_intp_y1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
+                block(b_blk_no)%pc(tar_x, tar_y, tar_z) = bl_interp_ans
+                block(b_blk_no)%pco(tar_x, tar_y, tar_z) = bl_interp_ans
 
-                bl_interp_ans1=(bl_intp_num/bl_intp_deno)
-                bl_intp_f1=block(a_blk_no)%pc(loc_x-1,loc_y-1,loc_z+1)
-                bl_intp_f2=block(a_blk_no)%pc(loc_x+1,loc_y-1,loc_z+1)
-                bl_intp_f3=block(a_blk_no)%pc(loc_x+1,loc_y+1,loc_z+1)
-                bl_intp_f4=block(a_blk_no)%pc(loc_x-1,loc_y+1,loc_z+1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-                bl_interp_ans2=(bl_intp_num/bl_intp_deno)
-                bl_interp_ans= bl_interp_ans1 + ((bl_intp_valz-bl_intp_z1)*((bl_interp_ans2 - &
-                     bl_interp_ans1)/(bl_intp_z2 - bl_intp_z1)))
-                block(b_blk_no)%pc(tar_x,tar_y,tar_z)=bl_interp_ans
-                block(b_blk_no)%pco(tar_x,tar_y,tar_z)=bl_interp_ans
-                ENDDO
-                ENDDO
-                ENDDO
+            ENDDO
+          ENDDO
+        ENDDO
 
         ENDDO
         ENDDO
         ENDDO
+        !$acc end parallel loop
+
 
      end do  ! axes loop
-
         ENDDO
 
 
@@ -723,4 +695,63 @@ SUBROUTINE fineUpdate_bd
         end do  ! axes
 
         end subroutine fineUpdate_bd_mv
+
+      !> Perform trilinear interpolation. Implemented as two bilinear
+      !> intepolations followed by a linear interpolation of the
+      !> results. See
+      !> https://en.wikipedia.org/wiki/Trilinear_interpolation.
+      !>
+      !> WARNING: that this lives in this module and not in the
+      !> Interpolation module as it contains some specific logic for
+      !> this module, namely the grid indices
+      pure function trilinear_interpolation(x, y, z, i, j, k, xgrid, ygrid, zgrid, offset, var) &
+           result(out)
+
+        !> The target position of the trilinear interpolation
+        real(dp), intent(in) :: x, y, z
+        !> Indices used to determine the grid locations
+        integer(int64), intent(in) :: i, j, k
+        !> The grids
+        real(dp), intent(in), dimension(:) :: xgrid, ygrid, zgrid
+        !> The offset value changes depending on whether we are computing p, u, v, or w
+        !> p=0, u=1, v=2, w=3
+        integer, intent(in) :: offset
+        !> The variable that is to be interpolated
+        real(dp), intent(in), dimension(:, :, :) :: var
+
+        !> The interpolated result
+        real(dp) :: out
+        ! Intermediate results used in the calculation
+        real(dp) :: z1, z2
+
+        ! Indices used to determine the variable indices after offsets
+        integer :: vi, vj, vk
+
+        vi = i
+        vj = j
+        vk = k
+
+        ! Set the indices appropiately
+        if (offset == 0) then
+           ! Leave everything as is
+        else if (offset == 1) then
+           vi = i - 1
+        else if (offset == 2) then
+           vj = j - 1
+        else if (offset == 3) then
+           vk = k - 1
+        else
+           ! Anything else is an error, but how to handle it?
+        end if
+
+        z1 = bilinear_interpolation(x, y, xgrid(i-1), xgrid(i+1), ygrid(j-1), ygrid(j+1), &
+                                   [var(vi-1, vj-1, vk-1), var(vi+1, vj-1, vk-1), &
+                                   var(vi-1, vj+1, vk-1), var(vi+1, vj+1, vk-1)])
+
+        z2 = bilinear_interpolation(x, y, xgrid(i-1), xgrid(i+1), ygrid(j-1), ygrid(j+1), &
+                                   [var(vi-1, vj-1, vk+1), var(vi+1, vj-1, vk+1), &
+                                   var(vi-1, vj+1, vk+1), var(vi+1, vj+1, vk+1)])
+
+        out = linear_interpolation(z, zgrid(k-1), zgrid(k+1), z1, z2)
+      end function trilinear_interpolation
 end module biocfd_fine_interp_bound

--- a/src/FineInterp_bound.f90
+++ b/src/FineInterp_bound.f90
@@ -285,12 +285,6 @@ SUBROUTINE fineUpdate_bd
         end subroutine fineUpdate_newv_bd
 
         SUBROUTINE fineUpdate_bd_mv(g)
-        REAL (dp) :: bl_intp_valx,bl_intp_valy,bl_intp_x1,bl_intp_x2,bl_intp_y1,bl_intp_y2,&
-             bl_intp_f1,bl_intp_f2,bl_intp_f3,bl_intp_f4
-        REAL (dp) :: bl_intp_valz,bl_intp_z1,bl_intp_z2
-        REAL (dp) :: bl_intp_deno, bl_intp_num, bl_intp_xtx, bl_intp_xxo, bl_intp_yty, &
-             bl_intp_yyo, bl_intp_first_term, bl_intp_second_term
-        REAL (dp) :: bl_interp_ans, bl_interp_ans1, bl_interp_ans2
 
         INTEGER(int64) :: i,j,k, varx1,varx2, vary1, vary2, tar_x, tar_y, loc_x, &
              loc_y, a_blk_no, b_blk_no
@@ -318,6 +312,10 @@ SUBROUTINE fineUpdate_bd
              steps(3) = intfr(g)%counterzp-1
         end if
 
+
+        !$acc parallel loop collapse(3) private(varx1, varx2, vary1, vary2, varz1, varz2) &
+        !$acc private(loc_x, loc_y, loc_z) &
+        !$acc firstprivate(a_blk_no, b_blk_no)
         DO k=1, intfr(g)%counterzp, steps(3)
         DO j=1, intfr(g)%counteryp, steps(2)
         DO i=1, intfr(g)%counterxp, steps(1)
@@ -333,45 +331,17 @@ SUBROUTINE fineUpdate_bd
         loc_y=intfr(g)%py_interface_det(1,j)
         loc_z=intfr(g)%pz_interface_det(1,k)
 
+        !$acc loop collapse(3) seq
         DO tar_z=varz1,varz2
         DO tar_y=vary1,vary2
         DO tar_x=varx1,varx2
 
-                bl_intp_valx=block(b_blk_no)%xp(tar_x)
-                bl_intp_valy=block(b_blk_no)%yp(tar_y)
-                bl_intp_valz=block(b_blk_no)%zp(tar_z)
-                bl_intp_x1=block(a_blk_no)%xp(loc_x-1)
-                bl_intp_x2=block(a_blk_no)%xp(loc_x+1)
-                bl_intp_y1=block(a_blk_no)%yp(loc_y-1)
-                bl_intp_y2=block(a_blk_no)%yp(loc_y+1)
-                bl_intp_z1=block(a_blk_no)%zp(loc_z-1)
-                bl_intp_z2=block(a_blk_no)%zp(loc_z+1)
-                bl_intp_f1=block(a_blk_no)%p(loc_x-1,loc_y-1,loc_z-1)
-                bl_intp_f2=block(a_blk_no)%p(loc_x+1,loc_y-1,loc_z-1)
-                bl_intp_f3=block(a_blk_no)%p(loc_x+1,loc_y+1,loc_z-1)
-                bl_intp_f4=block(a_blk_no)%p(loc_x-1,loc_y+1,loc_z-1)
+          block(b_blk_no)%p(tar_x,tar_y,tar_z) = trilinear_interpolation(&
+               block(b_blk_no)%xp(tar_x), block(b_blk_no)%yp(tar_y), block(b_blk_no)%zp(tar_z), &
+               loc_x, loc_y, loc_z, block(a_blk_no)%xp, block(a_blk_no)%yp, block(a_blk_no)%zp, &
+               0, block(a_blk_no)%p &
+          )
 
-                bl_intp_deno= (bl_intp_x2-bl_intp_x1) * (bl_intp_y2-bl_intp_y1)
-                bl_intp_xtx= (bl_intp_x2 -bl_intp_valx)
-                bl_intp_xxo=(bl_intp_valx-bl_intp_x1)
-                bl_intp_yty=(bl_intp_y2-bl_intp_valy)
-                bl_intp_yyo=(bl_intp_valy-bl_intp_y1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-
-                bl_interp_ans1=(bl_intp_num/bl_intp_deno)
-                bl_intp_f1=block(a_blk_no)%p(loc_x-1,loc_y-1,loc_z+1)
-                bl_intp_f2=block(a_blk_no)%p(loc_x+1,loc_y-1,loc_z+1)
-                bl_intp_f3=block(a_blk_no)%p(loc_x+1,loc_y+1,loc_z+1)
-                bl_intp_f4=block(a_blk_no)%p(loc_x-1,loc_y+1,loc_z+1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-                bl_interp_ans2=(bl_intp_num/bl_intp_deno)
-                bl_interp_ans= bl_interp_ans1 + ((bl_intp_valz-bl_intp_z1)*((bl_interp_ans2 - &
-                     bl_interp_ans1)/(bl_intp_z2 - bl_intp_z1)))
-                block(b_blk_no)%p(tar_x,tar_y,tar_z)=bl_interp_ans
                 ENDDO
                 ENDDO
                 ENDDO
@@ -379,6 +349,7 @@ SUBROUTINE fineUpdate_bd
         ENDDO
         ENDDO
         ENDDO
+         !$acc end parallel loop
 
         end do  ! axes
 
@@ -397,6 +368,9 @@ SUBROUTINE fineUpdate_bd
              steps(3) = intfr(g)%counterzu-1
         end if
 
+        !$acc parallel loop collapse(3) private(varx1, varx2, vary1, vary2, varz1, varz2) &
+        !$acc private(loc_x, loc_y, loc_z) &
+        !$acc firstprivate(a_blk_no, b_blk_no)
         DO k=1, intfr(g)%counterzu, steps(3)
         DO j=1, intfr(g)%counteryu, steps(2)
         DO i=1, intfr(g)%counterxu, steps(1)
@@ -412,45 +386,17 @@ SUBROUTINE fineUpdate_bd
         loc_y=intfr(g)%uy_interface_det(1,j)
         loc_z=intfr(g)%uz_interface_det(1,k)
 
+        !$acc loop collapse(3) seq
         DO tar_z=varz1,varz2
         DO tar_y=vary1,vary2
         DO tar_x=varx1,varx2
 
-                bl_intp_valx=block(b_blk_no)%xu(tar_x)
-                bl_intp_valy=block(b_blk_no)%yu(tar_y)
-                bl_intp_valz=block(b_blk_no)%zu(tar_z)
-                bl_intp_x1=block(a_blk_no)%xu(loc_x-1)
-                bl_intp_x2=block(a_blk_no)%xu(loc_x+1)
-                bl_intp_y1=block(a_blk_no)%yu(loc_y-1)
-                bl_intp_y2=block(a_blk_no)%yu(loc_y+1)
-                bl_intp_z1=block(a_blk_no)%zu(loc_z-1)
-                bl_intp_z2=block(a_blk_no)%zu(loc_z+1)
-                bl_intp_f1=block(a_blk_no)%u(loc_x-2,loc_y-1,loc_z-1)
-                bl_intp_f2=block(a_blk_no)%u(loc_x  ,loc_y-1,loc_z-1)
-                bl_intp_f3=block(a_blk_no)%u(loc_x  ,loc_y+1,loc_z-1)
-                bl_intp_f4=block(a_blk_no)%u(loc_x-2,loc_y+1,loc_z-1)
+               block(b_blk_no)%u(tar_x-1,tar_y,tar_z) = trilinear_interpolation(&
+               block(b_blk_no)%xu(tar_x), block(b_blk_no)%yu(tar_y), block(b_blk_no)%zu(tar_z), &
+               loc_x, loc_y, loc_z, block(a_blk_no)%xu, block(a_blk_no)%yu, block(a_blk_no)%zu, &
+               1, block(a_blk_no)%u &
+          )
 
-                bl_intp_deno= (bl_intp_x2-bl_intp_x1) * (bl_intp_y2-bl_intp_y1)
-                bl_intp_xtx= (bl_intp_x2 -bl_intp_valx)
-                bl_intp_xxo=(bl_intp_valx-bl_intp_x1)
-                bl_intp_yty=(bl_intp_y2-bl_intp_valy)
-                bl_intp_yyo=(bl_intp_valy-bl_intp_y1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-
-                bl_interp_ans1=(bl_intp_num/bl_intp_deno)
-                bl_intp_f1=block(a_blk_no)%u(loc_x-2,loc_y-1,loc_z+1)
-                bl_intp_f2=block(a_blk_no)%u(loc_x  ,loc_y-1,loc_z+1)
-                bl_intp_f3=block(a_blk_no)%u(loc_x  ,loc_y+1,loc_z+1)
-                bl_intp_f4=block(a_blk_no)%u(loc_x-2,loc_y+1,loc_z+1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-                bl_interp_ans2=(bl_intp_num/bl_intp_deno)
-                bl_interp_ans= bl_interp_ans1 + ((bl_intp_valz-bl_intp_z1)*((bl_interp_ans2 - &
-                     bl_interp_ans1)/(bl_intp_z2 - bl_intp_z1)))
-                block(b_blk_no)%u(tar_x-1,tar_y,tar_z)=bl_interp_ans
                 ENDDO
                 ENDDO
                 ENDDO
@@ -458,6 +404,7 @@ SUBROUTINE fineUpdate_bd
         ENDDO
         ENDDO
         ENDDO
+         !$acc end parallel loop
 
         end do  ! axes
 
@@ -476,6 +423,9 @@ SUBROUTINE fineUpdate_bd
              steps(3) = intfr(g)%counterzv-1
         end if
 
+        !$acc parallel loop collapse(3) private(varx1, varx2, vary1, vary2, varz1, varz2) &
+        !$acc private(loc_x, loc_y, loc_z) &
+        !$acc firstprivate(a_blk_no, b_blk_no)
         DO k=1, intfr(g)%counterzv, steps(3)
         DO j=1, intfr(g)%counteryv, steps(2)
         DO i=1, intfr(g)%counterxv, steps(1)
@@ -491,45 +441,17 @@ SUBROUTINE fineUpdate_bd
         loc_y=intfr(g)%vy_interface_det(1,j)
         loc_z=intfr(g)%vz_interface_det(1,k)
 
+        !$acc loop collapse(3) seq
         DO tar_z=varz1,varz2
         DO tar_y=vary1,vary2
         DO tar_x=varx1,varx2
 
-                bl_intp_valx=block(b_blk_no)%xv(tar_x)
-                bl_intp_valy=block(b_blk_no)%yv(tar_y)
-                bl_intp_valz=block(b_blk_no)%zv(tar_z)
-                bl_intp_x1=block(a_blk_no)%xv(loc_x-1)
-                bl_intp_x2=block(a_blk_no)%xv(loc_x+1)
-                bl_intp_y1=block(a_blk_no)%yv(loc_y-1)
-                bl_intp_y2=block(a_blk_no)%yv(loc_y+1)
-                bl_intp_z1=block(a_blk_no)%zv(loc_z-1)
-                bl_intp_z2=block(a_blk_no)%zv(loc_z+1)
-                bl_intp_f1=block(a_blk_no)%v(loc_x-1,loc_y-2,loc_z-1)
-                bl_intp_f2=block(a_blk_no)%v(loc_x+1,loc_y-2,loc_z-1)
-                bl_intp_f3=block(a_blk_no)%v(loc_x+1,loc_y  ,loc_z-1)
-                bl_intp_f4=block(a_blk_no)%v(loc_x-1,loc_y  ,loc_z-1)
+                 block(b_blk_no)%v(tar_x,tar_y-1,tar_z) = trilinear_interpolation(&
+               block(b_blk_no)%xv(tar_x), block(b_blk_no)%yv(tar_y), block(b_blk_no)%zv(tar_z), &
+               loc_x, loc_y, loc_z, block(a_blk_no)%xv, block(a_blk_no)%yv, block(a_blk_no)%zv, &
+               2, block(a_blk_no)%v &
+          )
 
-                bl_intp_deno= (bl_intp_x2-bl_intp_x1) * (bl_intp_y2-bl_intp_y1)
-                bl_intp_xtx= (bl_intp_x2 -bl_intp_valx)
-                bl_intp_xxo=(bl_intp_valx-bl_intp_x1)
-                bl_intp_yty=(bl_intp_y2-bl_intp_valy)
-                bl_intp_yyo=(bl_intp_valy-bl_intp_y1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-
-                bl_interp_ans1=(bl_intp_num/bl_intp_deno)
-                bl_intp_f1=block(a_blk_no)%v(loc_x-1,loc_y-2,loc_z+1)
-                bl_intp_f2=block(a_blk_no)%v(loc_x+1,loc_y-2,loc_z+1)
-                bl_intp_f3=block(a_blk_no)%v(loc_x+1,loc_y  ,loc_z+1)
-                bl_intp_f4=block(a_blk_no)%v(loc_x-1,loc_y  ,loc_z+1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-                bl_interp_ans2=(bl_intp_num/bl_intp_deno)
-                bl_interp_ans= bl_interp_ans1 + ((bl_intp_valz-bl_intp_z1)*((bl_interp_ans2 - &
-                     bl_interp_ans1)/(bl_intp_z2 - bl_intp_z1)))
-                block(b_blk_no)%v(tar_x,tar_y-1,tar_z)=bl_interp_ans
                 ENDDO
                 ENDDO
                 ENDDO
@@ -537,6 +459,7 @@ SUBROUTINE fineUpdate_bd
         ENDDO
         ENDDO
         ENDDO
+         !$acc end parallel loop
 
         end do  ! axes
 
@@ -555,6 +478,9 @@ SUBROUTINE fineUpdate_bd
              steps(3) = intfr(g)%counterzw-1
         end if
 
+        !$acc parallel loop collapse(3) private(varx1, varx2, vary1, vary2, varz1, varz2) &
+        !$acc private(loc_x, loc_y, loc_z) &
+        !$acc firstprivate(a_blk_no, b_blk_no)
         DO k=1, intfr(g)%counterzw, steps(3)
         DO j=1, intfr(g)%counteryw, steps(2)
         DO i=1, intfr(g)%counterxw, steps(1)
@@ -570,45 +496,17 @@ SUBROUTINE fineUpdate_bd
         loc_y=intfr(g)%wy_interface_det(1,j)
         loc_z=intfr(g)%wz_interface_det(1,k)
 
+        !$acc loop collapse(3) seq
         DO tar_z=varz1,varz2
         DO tar_y=vary1,vary2
         DO tar_x=varx1,varx2
 
-                bl_intp_valx=block(b_blk_no)%xw(tar_x)
-                bl_intp_valy=block(b_blk_no)%yw(tar_y)
-                bl_intp_valz=block(b_blk_no)%zw(tar_z)
-                bl_intp_x1=block(a_blk_no)%xw(loc_x-1)
-                bl_intp_x2=block(a_blk_no)%xw(loc_x+1)
-                bl_intp_y1=block(a_blk_no)%yw(loc_y-1)
-                bl_intp_y2=block(a_blk_no)%yw(loc_y+1)
-                bl_intp_z1=block(a_blk_no)%zw(loc_z-1)
-                bl_intp_z2=block(a_blk_no)%zw(loc_z+1)
-                bl_intp_f1=block(a_blk_no)%w(loc_x-1,loc_y-1,loc_z-2)
-                bl_intp_f2=block(a_blk_no)%w(loc_x+1,loc_y-1,loc_z-2)
-                bl_intp_f3=block(a_blk_no)%w(loc_x+1,loc_y+1,loc_z-2)
-                bl_intp_f4=block(a_blk_no)%w(loc_x-1,loc_y+1,loc_z-2)
+          block(b_blk_no)%w(tar_x,tar_y,tar_z-1) = trilinear_interpolation(&
+               block(b_blk_no)%xw(tar_x), block(b_blk_no)%yw(tar_y), block(b_blk_no)%zw(tar_z), &
+               loc_x, loc_y, loc_z, block(a_blk_no)%xw, block(a_blk_no)%yw, block(a_blk_no)%zw, &
+               3, block(a_blk_no)%w &
+          )
 
-                bl_intp_deno= (bl_intp_x2-bl_intp_x1) * (bl_intp_y2-bl_intp_y1)
-                bl_intp_xtx= (bl_intp_x2 -bl_intp_valx)
-                bl_intp_xxo=(bl_intp_valx-bl_intp_x1)
-                bl_intp_yty=(bl_intp_y2-bl_intp_valy)
-                bl_intp_yyo=(bl_intp_valy-bl_intp_y1)
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-
-                bl_interp_ans1=(bl_intp_num/bl_intp_deno)
-                bl_intp_f1=block(a_blk_no)%w(loc_x-1,loc_y-1,loc_z  )
-                bl_intp_f2=block(a_blk_no)%w(loc_x+1,loc_y-1,loc_z  )
-                bl_intp_f3=block(a_blk_no)%w(loc_x+1,loc_y+1,loc_z  )
-                bl_intp_f4=block(a_blk_no)%w(loc_x-1,loc_y+1,loc_z  )
-                bl_intp_first_term=(bl_intp_f1*bl_intp_xtx + bl_intp_f2*bl_intp_xxo)*bl_intp_yty
-                bl_intp_second_term=(bl_intp_f4*bl_intp_xtx + bl_intp_f3*bl_intp_xxo)*bl_intp_yyo
-                bl_intp_num= bl_intp_first_term + bl_intp_second_term
-                bl_interp_ans2=(bl_intp_num/bl_intp_deno)
-                bl_interp_ans= bl_interp_ans1 + ((bl_intp_valz-bl_intp_z1)*((bl_interp_ans2 - &
-                     bl_interp_ans1)/(bl_intp_z2 - bl_intp_z1)))
-                block(b_blk_no)%w(tar_x,tar_y,tar_z-1)=bl_interp_ans
                 ENDDO
                 ENDDO
                 ENDDO
@@ -616,6 +514,7 @@ SUBROUTINE fineUpdate_bd
         ENDDO
         ENDDO
         ENDDO
+        !$acc end parallel loop
 
         end do  ! axes
 


### PR DESCRIPTION
This is the next step in reducing the repetition in `FineInterp_bound`. I think we could perhaps even argue that this would maybe close #33, as removing the remaining repetition is a bit more involved, requiring us to change data structures.

## What's in this PR
- A new pure function `trilinear_interpolation`, that is very similar to what I did in #128 but ever so slightly different (a future task could be unifying them)
- Replace the "by-hand" interpolation in every subroutine with a call to the new function
- For good measure, I've added the OpenACC directives so that we can run this all on the GPU

I went through and tested that we don't change any of the values we set to e.g. `block(g)%p`, there are occasional small differences I put down to machine precision, but the majority of the time the results were exact.

As an aside
```console
❯ git show main:src/subFineInterp_bound.f90 | wc -l
    6989
❯ cat src/FineInterp_bound.f90 | wc -l
     581
```