### PR TITLE
Unused forcing variables

### DIFF
--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -1,6 +1,6 @@
 module biocfd_forcing
   use, intrinsic :: iso_fortran_env, only: dp => real64
-  use global, only : block, blk_start, nblocks, ac_y, ac_z, at_y, at_z, ac_x
+  use global, only : block, blk_start, nblocks, at_y, at_z
   use biocfd_interpolation, only: linear_interpolation, bilinear_interpolation
   implicit none
 
@@ -14,8 +14,7 @@ SUBROUTINE pressureForcing1
 
       INTEGER :: n, k, j, i, il, jl, kl, i_x1, i_y1, i_z1, g
       REAL (dp) :: n1, pos1_x, pos1_y, pos1_z, pt1, aval, bval, cval, p_pos1, sur2nodeDis, dpdn, &
-                   dpdn_e
-
+                   dpdn_e, ac_y, ac_z
       real(dp) :: derivatives(3)
       dpdn = 0._dp
         DO g=blk_start,nblocks
@@ -24,7 +23,7 @@ SUBROUTINE pressureForcing1
  !$acc parallel loop gang vector                                                                                          &
  !$acc private (n, n1, pos1_x, pos1_y, pos1_z, pt1, aval, bval, cval, p_pos1, sur2nodeDis, dpdn,                   &
  !$acc           dpdn_e, k, j, i, il, jl, kl, i_x1, i_y1,               &
- !$acc           i_z1,ac_z,ac_y,ac_x,at_y,at_z)         &
+ !$acc           i_z1,ac_z,ac_y,at_y,at_z)         &
  !$acc default(present)  &
  !$acc private(derivatives)
       DO n = 1, block(g)%ibCellCount
@@ -814,7 +813,7 @@ SUBROUTINE pressureForcingGhost
                          aval, bval, cval, p_pos1, sur2nodeDis, dpdn, &
                          p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, &
                          p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1, p_z1_x2, p_z2_x2, &
-                         h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e
+                         h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, ac_y, ac_z
 
         DO g=blk_start, nblocks
       dpdn = 0._dp
@@ -822,7 +821,7 @@ SUBROUTINE pressureForcingGhost
  !$acc private (n1, pos1_x, pos1_y, pos1_z, pt1, aval, bval, cval, p_pos1, sur2nodeDis, dpdn,                   &
  !$acc           p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1,                &
  !$acc           p_z1_x2, p_z2_x2, h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, k, j, i, il, jl, kl, i_x1, i_y1,               &
- !$acc           i_z1,ac_z,ac_y,ac_x,at_y,at_z)         &
+ !$acc           i_z1,ac_z,ac_y,at_y,at_z)         &
  !$acc default(present)
       DO n = 1, block(g)%TSCellCount
 
@@ -1699,7 +1698,7 @@ SUBROUTINE pressureForcingField
                          aval, bval, cval, p_pos1, sur2nodeDis, dpdn, &
                          p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, &
                          p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1, p_z1_x2, p_z2_x2, &
-                         h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e
+                         h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, ac_y, ac_z
 
        DO g=blk_start,nblocks
       dpdn = 0._dp
@@ -1707,7 +1706,7 @@ SUBROUTINE pressureForcingField
  !$acc private (n1, pos1_x, pos1_y, pos1_z, pt1, aval, bval, cval, p_pos1, sur2nodeDis, dpdn,                   &
  !$acc           p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1,                &
  !$acc           p_z1_x2, p_z2_x2, h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, k, j, i, il, jl, kl, i_x1, i_y1,               &
- !$acc           i_z1,ac_z,ac_y,ac_x,at_y,at_z)         &
+ !$acc           i_z1,ac_z,ac_y,at_y,at_z)         &
  !$acc default(present)
       DO n = 1, block(g)%ibCellCount
          IF (block(g)%ibSurfId(block(g)%nelp(n))==50) THEN

--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -1,6 +1,6 @@
 module biocfd_forcing
   use, intrinsic :: iso_fortran_env, only: dp => real64
-  use global, only : block, blk_start, nblocks, at_y, at_z
+  use global, only : block, blk_start, nblocks
   use biocfd_interpolation, only: linear_interpolation, bilinear_interpolation
   implicit none
 
@@ -14,7 +14,7 @@ SUBROUTINE pressureForcing1
 
       INTEGER :: n, k, j, i, il, jl, kl, i_x1, i_y1, i_z1, g
       REAL (dp) :: n1, pos1_x, pos1_y, pos1_z, pt1, aval, bval, cval, p_pos1, sur2nodeDis, dpdn, &
-                   dpdn_e, ac_y, ac_z
+                   dpdn_e, ac_y, ac_z, at_y, at_z
       real(dp) :: derivatives(3)
       dpdn = 0._dp
         DO g=blk_start,nblocks
@@ -813,7 +813,7 @@ SUBROUTINE pressureForcingGhost
                          aval, bval, cval, p_pos1, sur2nodeDis, dpdn, &
                          p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, p_x1_z1, p_x2_z1, &
                          p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1, p_z1_x2, p_z2_x2, &
-                         h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, ac_y, ac_z
+                         h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, ac_y, ac_z, at_y, at_z
 
         DO g=blk_start, nblocks
       dpdn = 0._dp
@@ -1698,7 +1698,7 @@ SUBROUTINE pressureForcingField
                          aval, bval, cval, p_pos1, sur2nodeDis, dpdn, &
                          p_x1, p_x2, p_y1, p_y2, p_z1, p_z2, &
                          p_x1_z1, p_x2_z1, p_x1_z2, p_x2_z2, p_z1_x1, p_z2_x1, p_z1_x2, p_z2_x2, &
-                         h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, ac_y, ac_z
+                         h1, h2, dpdn_e, dpdx_e, dpdy_e, dpdz_e, ac_y, ac_z, at_y, at_z
 
        DO g=blk_start,nblocks
       dpdn = 0._dp

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -2,7 +2,7 @@ module biocfd_search
   use, intrinsic :: iso_fortran_env, only: dp => real64, int64, int32
   use global, only: block, nblocks, blk_start, xfact, totime, theta_t, &
        theta_m, piv_pt, pi, phase_angle, ita, dxmin, deltat, aoa2, aoa1, aoa, &
-       ang_theta, alpha_t, alpha_m, ac_z, ac_y, ac_x, a0y, re, freq, inor, char_f, &
+       ang_theta, alpha_t, alpha_m, a0y, re, freq, inor, char_f, &
        intflines, coarse_flcnt_check, intfr
   use biocfd_fine_interp, only: fineUpdate_mv
   use biocfd_fine_interp_bound, only : fineUpdate_bd_mv
@@ -70,10 +70,6 @@ module biocfd_search
         bdfr=15
         bdy=15*dxmin
         angt  =  2._dp*pi*bdfr
-
-        ac_x=0.
-        ac_y=0.
-        ac_z=0.
 
         block(g)%xmove = 0.
         block(g)%ymove = 0.

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -24,8 +24,6 @@ MODULE global
 
         INTEGER (int64) ::nblocks, intflines
 
-       REAL(dp) :: at_x, at_y, at_z
-
         type Interfaces
 
         INTEGER(int64), ALLOCATABLE, DIMENSION (:,:) :: px_interface_det, ux_interface_det, &

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -24,8 +24,7 @@ MODULE global
 
         INTEGER (int64) ::nblocks, intflines
 
-       !at_x unused, but every other variable used below
-       REAL(dp) :: ac_x, ac_y, ac_z, at_x, at_y, at_z
+       REAL(dp) :: at_x, at_y, at_z
 
         type Interfaces
 


### PR DESCRIPTION
The variables `ac_x, ac_y, ac_z, at_x, at_y, at_z` are only used as private variables in the Forcing module and nowhere else, so they can be removed from global.