### PR TITLE
Fix bounds check issues

### DIFF
--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -312,7 +312,8 @@ contains
 !$acc           temp_v2dotn,temp_v1dotn, &
 !$acc           temp_w2dotn,temp_w1dotn, temp_pdotn) &
 !$acc default(present)   &
-!$acc firstprivate(nx_var, ny_var, nz_var, rev, deltat, al)
+!$acc firstprivate(nx_var, ny_var, nz_var, rev, deltat, al) &
+!$acc private(do_third_order_upwinding)
      DO n = 1, block(g)%fluidCellCount
 
       i = block(g)%fluidIndexPtr(n, 1)

--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -1,5 +1,5 @@
 module biocfd_navier_stokes
-  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use, intrinsic :: iso_fortran_env, only: dp => real64, int64
   use global, only : block, al, alpha, deltat, nblocks, re, rev
   implicit none
   private
@@ -287,6 +287,7 @@ contains
                        duwdx,dvwdy,dwwdz,d2wdx2,d2wdy2,d2wdz2,xtt2,residu,ytt2,residv,&
                           ztt2,residw, temp_u1dotn, temp_u2dotn, temp_v1dotn, temp_v2dotn, &
                           temp_w1dotn, temp_w2dotn, temp_pdotn
+         logical :: do_third_order_upwinding
      al = 1.
 
         DO g=1,nblocks
@@ -870,15 +871,20 @@ contains
            w_in_um=0.5_dp*(wu_n+wu_s)
 
 !cccccccccccccc---Third Order Upwinding ----ccccccccccccccccccccccccccccc
-       if(i>2.and.i<nx_var.and.j>2.and.j<ny_var+1.and. &
-      k>2.and.k<nz_var+1.and.block(g)%cell(i+1,j,k)/=2.and.     &
-      block(g)%cell(i-1,j,k)/=2.and.block(g)%cell(i,j+1,k)/=2.and.       &
-      block(g)%cell(i,j-1,k)/=2.and.block(g)%cell(i,j,k+1)/=2.and.       &
-      block(g)%cell(i,j,k-1)/=2.and.block(g)%cell2(i+2,j,k)/=2.and. &
-      block(g)%cell2(i,j+2,k)/=2.and.block(g)%cell2(i,j,k+2)/=2.and. &
-      block(g)%cell2(i-2,j,k)/=2.and.block(g)%cell2(i,j-2,k)/=2.and. &
-      block(g)%cell2(i,j,k-2)/=2) THEN
 
+           do_third_order_upwinding = .false.
+
+           if(i>2 .and. i<nx_var .and. j>2 .and. j<ny_var+1 .and. k>2 .and. k<nz_var+1) then
+              if (check_adjacent_cell(block(g)%cell, i, j, k, 1)) then
+                 if (check_adjacent_cell(block(g)%cell2, i, j, k, 2)) then
+                    do_third_order_upwinding = .true.
+                 end if
+              end if
+           end if
+
+
+
+       if (do_third_order_upwinding) then
 
            ddy=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j-1))
        ddye=0.5_dp*(block(g)%deltay(j)+block(g)%deltay(j+1))
@@ -953,14 +959,19 @@ contains
        w_in_vm=0.5_dp*(wv_n+wv_s)
 
 !cccccccccccccc---Third Order Upwinding ----cccccccccccccccccccccccccccc
-     if(i>2.and.i<nx_var+1.and.j>2.and.j<ny_var.and. &
-      k>2.and.k<nz_var+1.and.block(g)%cell(i+1,j,k)/=2.and.  &
-      block(g)%cell(i-1,j,k)/=2.and.block(g)%cell(i,j+1,k)/=2.and. &
-      block(g)%cell(i,j-1,k)/=2.and.block(g)%cell(i,j,k+1)/=2.and. &
-      block(g)%cell(i,j,k-1)/=2.and.block(g)%cell2(i+2,j,k)/=2.and. &
-      block(g)%cell2(i,j+2,k)/=2.and.block(g)%cell2(i,j,k+2)/=2.and. &
-      block(g)%cell2(i-2,j,k)/=2.and.block(g)%cell2(i,j-2,k)/=2.and. &
-      block(g)%cell2(i,j,k-2)/=2) THEN
+
+       do_third_order_upwinding = .false.
+
+       if(i>2 .and. i<nx_var+1 .and. j>2 .and. j<ny_var .and. k>2 .and. k<nz_var+1) then
+          if (check_adjacent_cell(block(g)%cell, i, j, k, 1)) then
+             if (check_adjacent_cell(block(g)%cell2, i, j, k, 2)) then
+                do_third_order_upwinding = .true.
+             end if
+          end if
+       end if
+
+       if (do_third_order_upwinding) then
+
        ddx=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i-1))
        ddxr=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i+1))
        ddz=0.5_dp*(block(g)%deltaz(k)+block(g)%deltaz(k-1))
@@ -1041,14 +1052,17 @@ contains
        v_in_wm=0.5_dp*(vw_n+vw_s)
 
 !cccccccccccccc---Third Order Upwinding ----ccccccccccccccccccccccccccccc
-     if(i>2.and.i<nx_var+1.and.j>2.and.j<ny_var+1.and. &
-      k>2.and.k<nz_var.and.block(g)%cell(i+1,j,k)/=2.and. &
-      block(g)%cell(i-1,j,k)/=2.and.block(g)%cell(i,j+1,k)/=2.and. &
-      block(g)%cell(i,j-1,k)/=2.and.block(g)%cell(i,j,k+1)/=2.and. &
-      block(g)%cell(i,j,k-1)/=2.and.block(g)%cell2(i+2,j,k)/=2.and. &
-      block(g)%cell2(i,j+2,k)/=2.and.block(g)%cell2(i,j,k+2)/=2.and. &
-      block(g)%cell2(i-2,j,k)/=2.and.block(g)%cell2(i,j-2,k)/=2.and. &
-      block(g)%cell2(i,j,k-2)/=2) THEN
+       do_third_order_upwinding = .false.
+
+       if(i>2 .and. i<nx_var+1 .and. j>2 .and. j<ny_var+1 .and. k>2 .and. k<nz_var) then
+          if (check_adjacent_cell(block(g)%cell, i, j, k, 1)) then
+             if (check_adjacent_cell(block(g)%cell2, i, j, k, 2)) then
+                do_third_order_upwinding = .true.
+             end if
+          end if
+       end if
+
+       if (do_third_order_upwinding) then
 
        ddx=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i-1))
        ddxr=0.5_dp*(block(g)%deltax(i)+block(g)%deltax(i+1))
@@ -1257,4 +1271,30 @@ ENDIF
        ak(6) = (theta(1)**2.0_dp)*theta(2)*(theta(3)+theta(3)**2.0_dp)
        ak(7) = (1.0_dp+theta(1))*(theta(3)+theta(3)**2.0_dp)*theta(2)
     end function compute_ak
+
+    !> Check whether adjacent cells in a taxicab geometry
+    !> (https://en.wikipedia.org/wiki/Taxicab_geometry), are equal to
+    !> two. The step size can be set.  Returns false if any of the
+    !> checked cell values equals 2 and true otherwise.
+    pure function check_adjacent_cell(cell, i, j, k, step) result(out)
+      !> The cell array to be checked
+      integer(int64), intent(in) :: cell(:, :, :)
+      !> The indices of the central value we are testing
+      integer(int64), intent(in) :: i, j, k
+      !> The step size in the x, y, and z directions to check
+      integer, intent(in) :: step
+      !> Will return false if any of the adjacent cells checked equals
+      !> 2 and true otherwise
+      logical :: out
+
+      out = .false.
+      if (cell(i - step, j, k) == 2) return
+      if (cell(i + step, j, k) == 2) return
+      if (cell(i, j - step, k) == 2) return
+      if (cell(i, j + step, k) == 2) return
+      if (cell(i, j, k - step) == 2) return
+      if (cell(i, j, k + step) == 2) return
+
+      out = .true.
+    end function check_adjacent_cell
 end module biocfd_navier_stokes

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -652,18 +652,16 @@ module biocfd_search
         ALLOCATE(block(g)%TSIndexPtr(block(g)%TSCellCount,3))
 
         iPt1 = 0
-                 DO k = 0, block(g)%nz+3
-                 DO j = 0, block(g)%ny+3
-                 DO i = 0, block(g)%nx+3
-                    IF (block(g)%cell2(i,j,k)==2) THEN
-                       iPt1 = iPt1 + 1
-                       block(g)%TSIndexPtr(iPt1, 1) = i
-                           block(g)%TSIndexPtr(iPt1, 2) = j
-                               block(g)%TSIndexPtr(iPt1, 3) = k
-                    ENDIF
-                 END DO
-                 END DO
-                 END DO
+        DO k=1, block(g)%nz+3
+           DO j=1, block(g)%ny+3
+              DO i=1, block(g)%nx+3
+                 IF (block(g)%cell2(i,j,k)==2) THEN
+                    iPt1 = iPt1 + 1
+                    block(g)%TSIndexPtr(iPt1, :) = [i, j, k]
+                 ENDIF
+              END DO
+           END DO
+        END DO
 
         ALLOCATE(&
           block(g)%u2_ghost(block(g)%TSCellCount),  &


### PR DESCRIPTION
This addresses the out-of-bounds errors and will close #118. 

There are fixed in two places. 

1. In Search, where a loop was starting at `0`. Looking at allocate arrays we can see that this is likely just a typo and the iteration should start at 1.
2. In NavierStokes, where the lack of short-circuiting if statements in fortran means that out-of-bounds access was occurring where it wouldn't if short circuiting was present. This is fixed along with a refactor to reduce a bit of repetition.