### PR TITLE
Unused time variables

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -2,7 +2,7 @@
       PROGRAM main
         use, intrinsic :: iso_fortran_env, only: int64, dp => real64
         USE global, only: block, blk_start, coarse_flcnt_check, couptime, deltat, istart, &
-             ita, ita1, ita2, itamax, nblocks, solvertime, totaltime, totime
+             ita, ita1, ita2, itamax, nblocks, totaltime, totime
         use biocfd_search, only: findDistnode, shiftSurfaceNodesInitial, computeSurfaceNorm, &
              tagging_th, tagging_th_move, block_move_check, cellcount_solid, &
              cellcount_solid_coarse, cellcount_solid_coarse_mv, change_block_coords, &
@@ -41,7 +41,6 @@
         totime = 0.
         ita1 = 0
         ita2 = 0
-        solverTime=0.
         coupTime=0.
         CALL tagging_th
         print*,'11'

--- a/app/main.F90
+++ b/app/main.F90
@@ -1,7 +1,7 @@
 
       PROGRAM main
         use, intrinsic :: iso_fortran_env, only: int64, dp => real64
-        USE global, only: block, blk_start, coarse_flcnt_check, couptime, deltat, istart, &
+        USE global, only: block, blk_start, coarse_flcnt_check, deltat, istart, &
              ita, ita1, ita2, itamax, nblocks, totaltime, totime
         use biocfd_search, only: findDistnode, shiftSurfaceNodesInitial, computeSurfaceNorm, &
              tagging_th, tagging_th_move, block_move_check, cellcount_solid, &
@@ -41,7 +41,6 @@
         totime = 0.
         ita1 = 0
         ita2 = 0
-        coupTime=0.
         CALL tagging_th
         print*,'11'
         CALL cellCount_solid

--- a/src/PcorVcor.F90
+++ b/src/PcorVcor.F90
@@ -1,7 +1,7 @@
 module biocfd_pcor_vcor
   use, intrinsic :: iso_fortran_env, only: dp => real64, int64
   use global, only : block, deltat, epsi, omega, omega1, omega2, omega3, omega4, pcitamax, &
-       amgxita, couptime, dfinish, dstart, ita, mstime, nblocks, solvertime, totaltime, &
+       amgxita, couptime, dfinish, dstart, ita, mstime, nblocks, totaltime, &
        totime
 #ifdef _OPENMP
   use omp_lib, only: omp_get_max_threads, omp_get_thread_num
@@ -79,7 +79,6 @@ module biocfd_pcor_vcor
         block(g)%derrStdSt=0._dp
         end do
 
-        solverTime=0.
      CALL cpu_time(dStart)
         CALL fineUpdate_newv_bd
         CALL coarseUpdate_newv
@@ -179,7 +178,8 @@ module biocfd_pcor_vcor
             WRITE(filename1,1)
  1          FORMAT('sphere_iter.dat')
          OPEN(111,FILE=filename1,POSITION='APPEND',STATUS='unknown')
-         WRITE(111,126)   ita, block(1)%nIterPcor, block(2)%nIterPcor, omega1, omega2, solverTime
+         ! Final 0. was solverTime, but this was never written to so was always 0.
+         WRITE(111,126)   ita, block(1)%nIterPcor, block(2)%nIterPcor, omega1, omega2, 0.
          WRITE(*,16) ita, max_nIterPcor, max_derr2, max_derrStdSt, totalTime
  126      FORMAT(' ',I8, 2I10, 2F6.2,F14.9)
  16      FORMAT(' ',I8, I10, 4E15.6)

--- a/src/PcorVcor.F90
+++ b/src/PcorVcor.F90
@@ -1,7 +1,7 @@
 module biocfd_pcor_vcor
   use, intrinsic :: iso_fortran_env, only: dp => real64, int64
   use global, only : block, deltat, epsi, omega, omega1, omega2, omega3, omega4, pcitamax, &
-       amgxita, couptime, dfinish, dstart, ita, mstime, nblocks, totaltime, &
+       amgxita, dfinish, dstart, ita, mstime, nblocks, totaltime, &
        totime
 #ifdef _OPENMP
   use omp_lib, only: omp_get_max_threads, omp_get_thread_num
@@ -84,7 +84,6 @@ module biocfd_pcor_vcor
         CALL coarseUpdate_newv
 
      CALL cpu_time(dfinish)
-        coupTime=coupTime + dfinish -dstart
 
         !$omp parallel num_threads(omp_threads) default(none) &
         !$omp& private(dStart, dfinish, amgxita, mstime, g) &
@@ -179,7 +178,7 @@ module biocfd_pcor_vcor
  1          FORMAT('sphere_iter.dat')
          OPEN(111,FILE=filename1,POSITION='APPEND',STATUS='unknown')
          ! Final 0. was solverTime, but this was never written to so was always 0.
-         WRITE(111,126)   ita, block(1)%nIterPcor, block(2)%nIterPcor, omega1, omega2, 0.
+         WRITE(111,126)   ita, block(1)%nIterPcor, block(2)%nIterPcor, omega1, omega2, 0._dp
          WRITE(*,16) ita, max_nIterPcor, max_derr2, max_derrStdSt, totalTime
  126      FORMAT(' ',I8, 2I10, 2F6.2,F14.9)
  16      FORMAT(' ',I8, I10, 4E15.6)

--- a/src/PcorVcor.F90
+++ b/src/PcorVcor.F90
@@ -1,7 +1,7 @@
 module biocfd_pcor_vcor
   use, intrinsic :: iso_fortran_env, only: dp => real64, int64
   use global, only : block, deltat, epsi, omega, omega1, omega2, omega3, omega4, pcitamax, &
-       amgxita, dfinish, dstart, ita, mstime, nblocks, totaltime, &
+       amgxita, dfinish, dstart, ita, nblocks, totaltime, &
        totime
 #ifdef _OPENMP
   use omp_lib, only: omp_get_max_threads, omp_get_thread_num
@@ -86,7 +86,7 @@ module biocfd_pcor_vcor
      CALL cpu_time(dfinish)
 
         !$omp parallel num_threads(omp_threads) default(none) &
-        !$omp& private(dStart, dfinish, amgxita, mstime, g) &
+        !$omp& private(dStart, dfinish, amgxita, g) &
         !$omp& shared(nblocks, acc_devices) firstprivate(omp_thread_num)
 
 #ifdef _OPENMP
@@ -120,7 +120,6 @@ module biocfd_pcor_vcor
          amgxita=0
          CALL REDBLACKSOR_linear(g)
          CALL cpu_time(dfinish)
-         msTime = msTime + dfinish-dstart
         end do
         !$omp end do
         !$omp single

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -18,7 +18,7 @@ MODULE global
                                 epsi, re, rev, &
                                 alpha, &
                                 xfact,deltat,totime, totalTime, dfinish, dstart, &
-                                pi , msTime, al, uc
+                                pi, al, uc
 
        REAL (dp)       :: alpha_m, theta_m, alpha_m1, theta_m1, mu_f, rho_f, l_c, u_tip, disp
 

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -17,7 +17,7 @@ MODULE global
                                 u0, v0, w0, &
                                 epsi, re, rev, &
                                 alpha, &
-                                xfact,deltat, coupTime,totime, totalTime, dfinish, dstart, &
+                                xfact,deltat,totime, totalTime, dfinish, dstart, &
                                 pi , msTime, al, uc
 
        REAL (dp)       :: alpha_m, theta_m, alpha_m1, theta_m1, mu_f, rho_f, l_c, u_tip, disp

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -18,7 +18,7 @@ MODULE global
                                 epsi, re, rev, &
                                 alpha, &
                                 xfact,deltat, coupTime,totime, totalTime, dfinish, dstart, &
-                                solverTime, pi , msTime, al, uc
+                                pi , msTime, al, uc
 
        REAL (dp)       :: alpha_m, theta_m, alpha_m1, theta_m1, mu_f, rho_f, l_c, u_tip, disp
 


### PR DESCRIPTION
These two timing variables are never really used for anything. We also have better ways of profiling performance such as running the `nsys` profiler.