### PR TITLE
Add explicit `blk` argument to allocateArrays

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -32,7 +32,9 @@
         CALL readInput
         CALL readBlockInterface
         CALL readSurfaceMeshGmsh
-        CALL allocateArrays
+        do g=1, size(block)
+          CALL allocateArrays(block(g))
+        end do
         CALL findDistnode
         CALL shiftSurfaceNodesInitial
         CALL computeSurfaceNorm

--- a/src/AllocateArrays.f90
+++ b/src/AllocateArrays.f90
@@ -3,7 +3,7 @@ module biocfd_allocate_arrays
     !  the program. Note that not all of the arrays are allocated
     !  here, several are allocated in other subroutines
     use, intrinsic :: iso_fortran_env, only: int64
-    use global, only : block
+    use biocfd_blocks, only: Blocks
     implicit none
     private
 
@@ -11,41 +11,39 @@ module biocfd_allocate_arrays
 
     contains
 
-    SUBROUTINE allocateArrays
+    SUBROUTINE allocateArrays(blk)
 
-        integer(int64) :: i
+        type(Blocks), intent(inout) :: blk
         integer(int64) :: nx, ny, nz
 
-        DO i=1, size(block)
-            nx = block(i)%nx
-            ny = block(i)%ny
-            nz = block(i)%nz
+        nx = blk%nx
+        ny = blk%ny
+        nz = blk%nz
 
-            ALLOCATE(&
-                block(i)%u(nx+2, ny+2, nz+2), &
-                block(i)%ut(nx+2, ny+2, nz+2), &
-                block(i)%v(nx+2, ny+2, nz+2), &
-                block(i)%vt(nx+2, ny+2, nz+2), &
-                block(i)%w(nx+2, ny+2, nz+2), &
-                block(i)%wt(nx+2, ny+2, nz+2),  &
-                block(i)%p(nx+2, ny+2, nz+2))
+        ALLOCATE(&
+            blk%u(nx+2, ny+2, nz+2), &
+            blk%ut(nx+2, ny+2, nz+2), &
+            blk%v(nx+2, ny+2, nz+2), &
+            blk%vt(nx+2, ny+2, nz+2), &
+            blk%w(nx+2, ny+2, nz+2), &
+            blk%wt(nx+2, ny+2, nz+2),  &
+            blk%p(nx+2, ny+2, nz+2))
 
-            ALLOCATE(&
-                block(i)%u_dum(nx+2, ny+2, nz+2), &
-                block(i)%v_dum(nx+2, ny+2, nz+2), &
-                block(i)%w_dum(nx+2, ny+2, nz+2), &
-                block(i)%p_dum(nx+2, ny+2, nz+2))
+        ALLOCATE(&
+            blk%u_dum(nx+2, ny+2, nz+2), &
+            blk%v_dum(nx+2, ny+2, nz+2), &
+            blk%w_dum(nx+2, ny+2, nz+2), &
+            blk%p_dum(nx+2, ny+2, nz+2))
 
-            ALLOCATE(block(i)%cell(nx+2,ny+2,nz+2))
-            ALLOCATE(block(i)%cell2(nx+3,ny+3,nz+3))
-            ALLOCATE(block(i)%cell_pr(nx+3,ny+3,nz+3))
-            ALLOCATE(block(i)%nodeIdTag(nx+3,ny+3,nz+3))
-            ALLOCATE(block(i)%b(nx+2,ny+2,nz+2))
-            ALLOCATE(block(i)%cell_n(nx+2,ny+2,nz+2))
-            ALLOCATE(block(i)%Acx(nx,3), block(i)%Acy(ny,3), block(i)%Acz(nz,3))
-            ALLOCATE(block(i)%pc(nx+2,ny+2, nz+2), block(i)%pco(nx+2,ny+2, nz+2))
+        ALLOCATE(blk%cell(nx+2,ny+2,nz+2))
+        ALLOCATE(blk%cell2(nx+3,ny+3,nz+3))
+        ALLOCATE(blk%cell_pr(nx+3,ny+3,nz+3))
+        ALLOCATE(blk%nodeIdTag(nx+3,ny+3,nz+3))
+        ALLOCATE(blk%b(nx+2,ny+2,nz+2))
+        ALLOCATE(blk%cell_n(nx+2,ny+2,nz+2))
+        ALLOCATE(blk%Acx(nx,3), blk%Acy(ny,3), blk%Acz(nz,3))
+        ALLOCATE(blk%pc(nx+2,ny+2, nz+2), blk%pco(nx+2,ny+2, nz+2))
 
-        END DO
 
       END SUBROUTINE allocateArrays
 end module biocfd_allocate_arrays


### PR DESCRIPTION
- Adds an argument to the `allocateArrays` subroutine
- Chose `blk` because don't want to use [block](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2023-1/block.html) (and nice and concise) but happy to change it to something else if people prefer?
- Move the loop over blocks to the main program. A consequence of this will be that we'll get lots of loops over blocks in `main`, but eventually we'll be able to combine some together. 
