### PR TITLE
Remove unused minElemcell Block variable

### DIFF
--- a/src/Blocks.f90
+++ b/src/Blocks.f90
@@ -17,7 +17,6 @@ MODULE biocfd_blocks
                                      j_startSearch, j_endSearch, &
                                      i_startSearch, i_endSearch
        INTEGER (int64), ALLOCATABLE, DIMENSION (:,:,:) :: cell, cell2, cell_n, cell_pr,nodeIdTag
-       INTEGER (int64), ALLOCATABLE, DIMENSION (:,:,:) :: minElemcell
 
        REAL (dp), ALLOCATABLE, DIMENSION (:) :: deltax, deltay, deltaz, x1, y1, z1, &
             xu, yu, zu, xv, yv, zv, xw, yw, zw, xp, yp, zp

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -1053,7 +1053,6 @@ block(g)%fluidCellCount = flcnt
         END DO
         !$acc end parallel loop
 
-        ! DEALLOCATE (block(g)%minElemcell)
          END DO
          print*, 'computeNormDistance done'
 


### PR DESCRIPTION
minElemcell is never used. There is only one reference to it in the code. A commented line about it being deallocated.