### PR TITLE
Remove unused fluidInterceptedIndexPtr variable Block variable

### DIFF
--- a/src/Blocks.f90
+++ b/src/Blocks.f90
@@ -39,7 +39,7 @@ MODULE biocfd_blocks
                           blackCellCount, TSCellCount
 
        INTEGER (int64), ALLOCATABLE, DIMENSION (:, :) :: TSIndexPtr, interceptedIndexPtr, &
-                                                         solidIndexPtr, fluidInterceptedIndexPtr
+                                                         solidIndexPtr
 
 
        INTEGER (int64), ALLOCATABLE, DIMENSION (:) :: nelp, nelu1, nelu2, nelv1, nelv2, nelw1, nelw2


### PR DESCRIPTION
fluidInterceptedIndexPtr is not used anywhere in the code, so this PR removes it.