### PR TITLE
Remove unused alphaDDot variable from Block type

### DIFF
--- a/src/Blocks.f90
+++ b/src/Blocks.f90
@@ -67,7 +67,7 @@ MODULE biocfd_blocks
        INTEGER (int64) :: cpy_x_start, cpy_x_end, cpy_y_start, cpy_y_end
        INTEGER (int64) :: cpy_z_start, cpy_z_end
        REAL (dp) :: theta, thetaDot, thetaDDot, piv_x,piv_y, piv_z
-       REAL (dp) :: alphaDot, alphaDDot, thetaDot1, thetaDDot1, thetaDot2, thetaDDot2
+       REAL (dp) :: alphaDot, thetaDot1, thetaDDot1, thetaDot2, thetaDDot2
 
 
     end type Blocks

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -95,7 +95,6 @@ module biocfd_search
         block(g)%thetaDot1  = 0.
         block(g)% thetaDot2  = 0.
         block(g)% alphaDot  = 0.
-        block(g)%alphaDDot  = 0.  !-ang_theta*ang_theta*a0*sin(2._dp*pi*freq*totime + phase_angle)
         block(g)% thetaDDot1 = 0.
         block(g)%thetaDDot2 = 0.
         block(g)% thetaDDot  = 0.  !-ang_theta*ang_theta*a0*sin(2._dp*pi*freq*totime + phase_angle)


### PR DESCRIPTION
alphaDDot is set to 0 but never used, so can probably be removed.