### PR TITLE
Add explicit `blk` argument to `findDistNode`

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -35,7 +35,9 @@
         do g=1, size(block)
           CALL allocateArrays(block(g))
         end do
-        CALL findDistnode
+        do g=blk_start, size(block)
+           CALL findDistnode(block(g))
+        end do
         CALL shiftSurfaceNodesInitial
         CALL computeSurfaceNorm
         CALL interfaceDetail

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -6,6 +6,7 @@ module biocfd_search
        intflines, coarse_flcnt_check, intfr
   use biocfd_fine_interp, only: fineUpdate_mv
   use biocfd_fine_interp_bound, only : fineUpdate_bd_mv
+  use biocfd_blocks, only: Blocks
   implicit NONE
 
   private

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -21,7 +21,7 @@ module biocfd_search
     SUBROUTINE findDistnode(blk)
       type(Blocks), intent(inout) :: blk
         REAL(dp)      ::  dist, dist1, dist2
-        INTEGER(int64) ::  i, g
+        INTEGER(int64) ::  i
 
         dist=0.
         dist1=999999.

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -17,33 +17,31 @@ module biocfd_search
   public :: fine_block_cell, selectiveretagging_th
 
   contains
-        SUBROUTINE findDistnode
+    SUBROUTINE findDistnode(blk)
+      type(Blocks), intent(inout) :: blk
         REAL(dp)      ::  dist, dist1, dist2
         INTEGER(int64) ::  i, g
 
-
-        DO g=blk_start,nblocks
         dist=0.
         dist1=999999.
         dist2=0.
-        DO i = 1, block(g)%ibnodes
-        IF (block(g)%ibNodeId(i)==51) THEN
-                if (abs(block(g)%znode(i)) > dist)then
-                        dist=block(g)%znode(i)
-                        block(g)%mk=i
+        DO i = 1, blk%ibnodes
+        IF (blk%ibNodeId(i)==51) THEN
+                if (abs(blk%znode(i)) > dist)then
+                        dist=blk%znode(i)
+                        blk%mk=i
                 endif
         ENDIF
-        IF (block(g)%ibNodeId(i)==51) THEN
-                if (abs(block(g)%xnode(i)) < dist1)then
-                        dist1=block(g)%xnode(i)
-                        block(g)%mkx1=i
+        IF (blk%ibNodeId(i)==51) THEN
+                if (abs(blk%xnode(i)) < dist1)then
+                        dist1=blk%xnode(i)
+                        blk%mkx1=i
                 endif
-                if (abs(block(g)%xnode(i)) > dist2)then
-                        dist2=block(g)%xnode(i)
-                        block(g)%mkx2=i
+                if (abs(blk%xnode(i)) > dist2)then
+                        dist2=blk%xnode(i)
+                        blk%mkx2=i
                 endif
         ENDIF
-        ENDDO
         ENDDO
         end subroutine findDistnode
 

--- a/test/test_search.f90
+++ b/test/test_search.f90
@@ -18,6 +18,7 @@ contains
 
 
   subroutine test_find_dist_node(error)
+    use biocfd_blocks, only : Blocks
     use biocfd_search, only : findDistnode
     use global, only : block, blk_start, nblocks
     !> Error handling
@@ -25,32 +26,30 @@ contains
 
     integer(int64) :: expected
     integer :: ibnodes
+    type(Blocks) :: blk
 
     ! Setup the required block variables
-    blk_start = 1
-    nblocks = 1
     ibnodes = 6
-    allocate(block(nblocks))
-    block(1)%ibnodes = ibnodes
+    blk%ibnodes = ibnodes
 
     ! Although not required by fortran>=2003 Lfortran requires arrays
     ! to be allocated before they are assigned to see
     ! https://github.com/lfortran/lfortran/issues/2946
     allocate(&
-         block(1)%ibNodeId(ibnodes), &
-         block(1)%xnode(ibnodes), &
-         block(1)%ynode(ibnodes), &
-         block(1)%znode(ibnodes) &
+         blk%ibNodeId(ibnodes), &
+         blk%xnode(ibnodes), &
+         blk%ynode(ibnodes), &
+         blk%znode(ibnodes) &
     )
 
-    block(1)%ibNodeId = [51, 51, 51, 51, 51, 51]
-    block(1)%xnode = [0, -7, -4, 1, -10, 8]
-    block(1)%ynode = [0, -7, -4, 1, -10, 8]
-    block(1)%znode = [0, -7, -4, 1, -10, 8]
+    blk%ibNodeId = [51, 51, 51, 51, 51, 51]
+    blk%xnode = [0, -7, -4, 1, -10, 8]
+    blk%ynode = [0, -7, -4, 1, -10, 8]
+    blk%znode = [0, -7, -4, 1, -10, 8]
 
-    call findDistnode
+    call findDistnode(blk)
     expected = 6
-    call check(error, block(1)%mk, expected)
+    call check(error, blk%mk, expected)
     if (allocated(error)) return
   end subroutine test_find_dist_node
 end module test_search

--- a/test/test_search.f90
+++ b/test/test_search.f90
@@ -20,7 +20,6 @@ contains
   subroutine test_find_dist_node(error)
     use biocfd_blocks, only : Blocks
     use biocfd_search, only : findDistnode
-    use global, only : block, blk_start, nblocks
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
 


### PR DESCRIPTION
Makes `findDistNode` (which may or may not be doing what we want it to #21) take a `blk` argument and moves the loop over blocks from the subroutine into the main program. This is useful for the MPI work. Required updating the test.