### PR TITLE
Update test-drive to v0.5.0

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -18,7 +18,7 @@ library = false
 
 [dev-dependencies]
 test-drive.git = "https://github.com/fortran-lang/test-drive"
-test-drive.tag = "v0.4.0"
+test-drive.tag = "v0.5.0"
 
 [extra.fortitude.check]
 select = ["ALL"]


### PR DESCRIPTION
This PR updates test-drive to v0.5.0 now it has been released.