### PR TITLE
Remove block, blk_start, nblocks from use global BoundaryConditions.f90

### DIFF
--- a/src/BoundaryConditions.f90
+++ b/src/BoundaryConditions.f90
@@ -1,6 +1,6 @@
 module biocfd_boundary_conditions
   use, intrinsic :: iso_fortran_env, only: dp => real64, int64
-  use global, only : block, blk_start, nblocks, deltat, uc
+  use global, only : deltat, uc
   use biocfd_blocks,only : Blocks
   implicit none
   private


### PR DESCRIPTION
Now blk is an argument of all the subroutines in BoundaryConditions.f90 we can remove block, blk_start, nblocks from use global in BoundaryConditions.f90