### PR TITLE
Remove use global from Forcing.f90

### DIFF
--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -1,6 +1,5 @@
 module biocfd_forcing
   use, intrinsic :: iso_fortran_env, only: dp => real64
-  use global, only : block, blk_start, nblocks
   use biocfd_interpolation, only: linear_interpolation, bilinear_interpolation
   use biocfd_blocks,only : Blocks
   implicit none


### PR DESCRIPTION
Now that blk is an argument of the subroutines in Forcing.f90 we should be able to remove the use global line from the file.