### PR TITLE
Remove use Global from BoundaryConditions.f90

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -115,7 +115,7 @@
         do g=blk_start, size(block)
            CALL velocityForcing1(block(g))
         end do
-        CALL velocityBC(block(1))
+        CALL velocityBC(block(1),deltat,uc)
         CALL poissonSolver(pcItaMax)
         print *,7
         do g=blk_start, size(block)

--- a/app/main.F90
+++ b/app/main.F90
@@ -3,7 +3,7 @@
         use, intrinsic :: iso_fortran_env, only: int64, dp => real64
         USE global, only: block, blk_start, coarse_flcnt_check, deltat, istart, &
              ita, ita1, ita2, itamax, nblocks, totaltime, totime,a0y,alpha_m, &
-             alpha_t,ang_theta,aoa,aoa1,aoa2,phase_angle,pi,theta_m,theta_t
+             alpha_t,ang_theta,aoa,aoa1,aoa2,phase_angle,pi,theta_m,theta_t,uc
         use biocfd_search, only: findDistnode, shiftSurfaceNodesInitial, computeSurfaceNorm, &
              tagging_th, tagging_th_move, block_move_check, cellcount_solid, &
              cellcount_solid_coarse, cellcount_solid_coarse_mv, change_block_coords, &
@@ -90,7 +90,7 @@
         ita2 = ita2 + 1
         totime = totime + deltat
         CALL nsMomentum2order
-        CALL velocityBC(block(1))
+        CALL velocityBC(block(1),deltat,uc)
         do g=blk_start, size(block)
            CALL solidCellBC(block(g))
         end do
@@ -98,7 +98,7 @@
         do g=blk_start, size(block)
            CALL velocityForcing1(block(g))
         end do
-        CALL velocityBC(block(1))
+        CALL velocityBC(block(1),deltat,uc)
         CALL poissonSolver
         print *,7
         do g=blk_start, size(block)

--- a/app/main.F90
+++ b/app/main.F90
@@ -3,7 +3,7 @@
         use, intrinsic :: iso_fortran_env, only: int64, dp => real64
         USE global, only: block, blk_start, coarse_flcnt_check, deltat, istart, &
              ita, ita1, ita2, itamax, nblocks, totaltime, totime,alpha_m, &
-             ang_theta,aoa,aoa1,aoa2,phase_angle,pi,theta_m,theta_t,uc
+             ang_theta,aoa,aoa1,aoa2,phase_angle,pi,theta_m,uc
         use biocfd_search, only: findDistnode, shiftSurfaceNodesInitial, computeSurfaceNorm, &
              tagging_th, tagging_th_move, block_move_check, cellcount_solid, &
              cellcount_solid_coarse, cellcount_solid_coarse_mv, change_block_coords, &

--- a/src/BoundaryConditions.f90
+++ b/src/BoundaryConditions.f90
@@ -11,7 +11,7 @@ module biocfd_boundary_conditions
 SUBROUTINE velocityBC(blk,deltat,uc)
       type(Blocks), intent(inout) :: blk
       INTEGER (int64):: i, j, k
-      REAL(dp) :: deltat,uc
+      REAL(dp), intent(in) :: deltat,uc
       
      !$acc parallel loop gang vector collapse (2) default(present)  &
      !$acc firstprivate (uc, deltat)

--- a/src/BoundaryConditions.f90
+++ b/src/BoundaryConditions.f90
@@ -1,6 +1,5 @@
 module biocfd_boundary_conditions
   use, intrinsic :: iso_fortran_env, only: dp => real64, int64
-  use global, only : deltat, uc
   use biocfd_blocks,only : Blocks
   implicit none
   private
@@ -9,10 +8,11 @@ module biocfd_boundary_conditions
 
   contains
 
-SUBROUTINE velocityBC(blk)
+SUBROUTINE velocityBC(blk,deltat,uc)
       type(Blocks), intent(inout) :: blk
       INTEGER (int64):: i, j, k
-
+      REAL(dp) :: deltat,uc
+      
      !$acc parallel loop gang vector collapse (2) default(present)  &
      !$acc firstprivate (uc, deltat)
       DO  k = 2, blk%nz+1

--- a/src/BoundaryConditions.f90
+++ b/src/BoundaryConditions.f90
@@ -12,7 +12,7 @@ SUBROUTINE velocityBC(blk,deltat,uc)
       type(Blocks), intent(inout) :: blk
       INTEGER (int64):: i, j, k
       REAL(dp), intent(in) :: deltat,uc
-      
+
      !$acc parallel loop gang vector collapse (2) default(present)  &
      !$acc firstprivate (uc, deltat)
       DO  k = 2, blk%nz+1

--- a/src/PcorVcor.F90
+++ b/src/PcorVcor.F90
@@ -2,7 +2,7 @@ module biocfd_pcor_vcor
   use, intrinsic :: iso_fortran_env, only: dp => real64, int64
   use global, only : block, deltat, epsi, omega, omega1, omega2, omega3, omega4, pcitamax, &
        amgxita, dfinish, dstart, ita, nblocks, totaltime, &
-       totime
+       totime,uc
 #ifdef _OPENMP
   use omp_lib, only: omp_get_max_threads, omp_get_thread_num
 #endif
@@ -133,7 +133,7 @@ module biocfd_pcor_vcor
         END DO
         !$omp end do
         !$omp end parallel
-         CALL velocityBC(block(1))      !correct velocity at boundaries
+         CALL velocityBC(block(1),deltat,uc)      !correct velocity at boundaries
 
          DO g=1,nblocks
          err_ds=0.


### PR DESCRIPTION
Now that blk has been made an argument of the subroutines in BoundaryConditions.f90, it is not too much effort to remove the few variables still being used in the Global module from BoundaryConditions.f90, so this PR removes them.