### PR TITLE
Make alpha a parameter of Navier-Stokes

### DIFF
--- a/src/NavierStokes.f90
+++ b/src/NavierStokes.f90
@@ -1,9 +1,11 @@
 module biocfd_navier_stokes
   use, intrinsic :: iso_fortran_env, only: dp => real64, int64
-  use global, only : alpha, deltat, re
+  use global, only : deltat, re
   use biocfd_blocks, only: Blocks
   implicit none
   private
+
+  real(dp), parameter :: alpha = 1._dp
 
   public :: non_uni_coeff, nsmomentum2order
 

--- a/src/ReadInput.f90
+++ b/src/ReadInput.f90
@@ -4,7 +4,7 @@ module biocfd_read_input
        re, piv_pt, pi, phase_angle, omega4, &
        omega3, omega2, omega1, nblocks, ita1, ita, &
        intflines, inor, freq, epsi, dxmin, dt_order, deltat, &
-       blk_start, aoa, alpha, intfr
+       blk_start, aoa, intfr
   use biocfd_interface_type, only: Interface_t
   use biocfd_blocks,only : Blocks
   implicit none
@@ -100,7 +100,6 @@ module biocfd_read_input
         freq = freq*u0/l_c
         deltat = 1._dp/(4._dp*freq*dt_order)  !0.00041666666666_dp! *5e-4
         disp = block(blk_start)%a0*cos(2*pi*freq*deltat)
-        alpha  = 1._dp
        u_tip=4*((pi*45)/180)*l_c*freq
 
         Print*, 'dxmin =', dxmin

--- a/src/modGlobal.f90
+++ b/src/modGlobal.f90
@@ -12,7 +12,6 @@ MODULE global
                                 freq, &
                                 u0, &
                                 epsi, re, &
-                                alpha, &
                                 deltat, totime, totalTime, &
                                 uc
        real(dp), parameter :: pi = 4._dp * atan(1._dp)


### PR DESCRIPTION
Suggested by @mcbarton in #19. Pretty sure `alpha` is only used in Navier-Stokes (and is always set to 1)