### PR TITLE
Refactor change block interface

### DIFF
--- a/src/InterfaceDetail.f90
+++ b/src/InterfaceDetail.f90
@@ -4,7 +4,7 @@ module biocfd_interface_detail
   implicit none
   private
 
-  public :: interfaceDetail
+  public :: interfaceDetail, print_interface_detail
 
   contains
 SUBROUTINE interfaceDetail

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -6,6 +6,7 @@ module biocfd_search
        coarse_flcnt_check, intfr
   use biocfd_fine_interp, only: fineUpdate_mv
   use biocfd_fine_interp_bound, only : fineUpdate_bd_mv
+  use biocfd_interface_detail, only : print_interface_detail
   use biocfd_block_type, only: Block_t
   implicit NONE
 
@@ -1384,155 +1385,102 @@ blk%fluidCellCount = flcnt
 
 SUBROUTINE change_block_interface
 
-        INTEGER(int64) :: i,j,g, a_blk_no, b_blk_no, factor,k,increment
+  INTEGER(int64) :: i,j,g, a_blk_no, b_blk_no, factor,k,increment
 
-        DO g=1,size(intfr)
-        a_blk_no=intfr(g)%a_blk
-        b_blk_no=intfr(g)%b_blk
-        factor=intfr(g)%b_msh/intfr(g)%a_msh
-        increment = block(b_blk_no)%move_amtx/factor
-        if ( block(b_blk_no)% move_check == 1) then
+  do g=1,size(intfr)
+     b_blk_no=intfr(g)%b_blk
+     if ( block(b_blk_no)% move_check /= 1) cycle
+     a_blk_no=intfr(g)%a_blk
+     factor=intfr(g)%b_msh/intfr(g)%a_msh
+     increment = block(b_blk_no)%move_amtx/factor
 
-        intfr(g)%px_interface_det(1,1:intfr(g)%counterxp) =&
-              intfr(g)%px_interface_det(1,1:intfr(g)%counterxp) + increment
+     intfr(g)%px_interface_det(1,1:intfr(g)%counterxp) =&
+             intfr(g)%px_interface_det(1,1:intfr(g)%counterxp) + increment
 
-        intfr(g)%ux_interface_det(1,1:intfr(g)%counterxu) =&
-              intfr(g)%ux_interface_det(1,1:intfr(g)%counterxu) + increment
+     intfr(g)%ux_interface_det(1,1:intfr(g)%counterxu) =&
+             intfr(g)%ux_interface_det(1,1:intfr(g)%counterxu) + increment
 
-        intfr(g)%vx_interface_det(1,1:intfr(g)%counterxv) =&
-              intfr(g)%vx_interface_det(1,1:intfr(g)%counterxv) + increment
+     intfr(g)%vx_interface_det(1,1:intfr(g)%counterxv) =&
+             intfr(g)%vx_interface_det(1,1:intfr(g)%counterxv) + increment
 
-        intfr(g)%wx_interface_det(1,1:intfr(g)%counterxw) =&
-              intfr(g)%wx_interface_det(1,1:intfr(g)%counterxw) + increment
+     intfr(g)%wx_interface_det(1,1:intfr(g)%counterxw) =&
+             intfr(g)%wx_interface_det(1,1:intfr(g)%counterxw) + increment
 
-        intfr(g)%py_interface_det(1,1:intfr(g)%counteryp) =&
-              intfr(g)%py_interface_det(1,1:intfr(g)%counteryp) + increment
+     intfr(g)%py_interface_det(1,1:intfr(g)%counteryp) =&
+             intfr(g)%py_interface_det(1,1:intfr(g)%counteryp) + increment
 
-        intfr(g)%uy_interface_det(1,1:intfr(g)%counteryu) =&
-              intfr(g)%uy_interface_det(1,1:intfr(g)%counteryu) + increment
+     intfr(g)%uy_interface_det(1,1:intfr(g)%counteryu) =&
+             intfr(g)%uy_interface_det(1,1:intfr(g)%counteryu) + increment
 
-        intfr(g)%vy_interface_det(1,1:intfr(g)%counteryv) =&
-              intfr(g)%vy_interface_det(1,1:intfr(g)%counteryv) + increment
+     intfr(g)%vy_interface_det(1,1:intfr(g)%counteryv) =&
+             intfr(g)%vy_interface_det(1,1:intfr(g)%counteryv) + increment
 
-        intfr(g)%wy_interface_det(1,1:intfr(g)%counteryw) =&
-              intfr(g)%wy_interface_det(1,1:intfr(g)%counteryw) + increment
+     intfr(g)%wy_interface_det(1,1:intfr(g)%counteryw) =&
+             intfr(g)%wy_interface_det(1,1:intfr(g)%counteryw) + increment
 
-        intfr(g)%pz_interface_det(1,1:intfr(g)%counterzp) =&
-              intfr(g)%pz_interface_det(1,1:intfr(g)%counterzp) + increment
+     intfr(g)%pz_interface_det(1,1:intfr(g)%counterzp) =&
+             intfr(g)%pz_interface_det(1,1:intfr(g)%counterzp) + increment
 
-        intfr(g)%uz_interface_det(1,1:intfr(g)%counterzu) =&
+     intfr(g)%uz_interface_det(1,1:intfr(g)%counterzu) =&
               intfr(g)%uz_interface_det(1,1:intfr(g)%counterzu) + increment
 
-        intfr(g)%vz_interface_det(1,1:intfr(g)%counterzv) =&
-              intfr(g)%vz_interface_det(1,1:intfr(g)%counterzv) + increment
+     intfr(g)%vz_interface_det(1,1:intfr(g)%counterzv) =&
+             intfr(g)%vz_interface_det(1,1:intfr(g)%counterzv) + increment
 
-        intfr(g)%wz_interface_det(1,1:intfr(g)%counterzw) =&
-              intfr(g)%wz_interface_det(1,1:intfr(g)%counterzw) + increment
+     intfr(g)%wz_interface_det(1,1:intfr(g)%counterzw) =&
+             intfr(g)%wz_interface_det(1,1:intfr(g)%counterzw) + increment
 
+     do j=1,size(intfr)
+        call print_interface_detail("px", intfr(j)%counterxp, intfr(j)%px_interface_det, &
+                                    block(a_blk_no)%xp, block(b_blk_no)%xp)
+     end do
+     do j=1,size(intfr)
+        call print_interface_detail("py", intfr(j)%counteryp, intfr(j)%py_interface_det, &
+                                    block(a_blk_no)%yp, block(b_blk_no)%yp)
+     end do
+     do j=1,size(intfr)
+        call print_interface_detail("pz", intfr(j)%counterzp, intfr(j)%pz_interface_det, &
+                                    block(a_blk_no)%zp, block(b_blk_no)%zp)
+     end do
+     do j=1,size(intfr)
+        call print_interface_detail("ux", intfr(j)%counterxu, intfr(j)%ux_interface_det, &
+                                    block(a_blk_no)%xu, block(b_blk_no)%xu)
+     end do
+     do j=1,size(intfr)
+        call print_interface_detail("uy", intfr(j)%counteryu, intfr(j)%uy_interface_det, &
+                                    block(a_blk_no)%yu, block(b_blk_no)%yu)
+      end do
+      do j=1,size(intfr)
+         call print_interface_detail("uz", intfr(j)%counterzu, intfr(j)%uz_interface_det, &
+                                     block(a_blk_no)%zu, block(b_blk_no)%zu)
+      end do
+      do j=1,size(intfr)
+         call print_interface_detail("vx", intfr(j)%counterxv, intfr(j)%vx_interface_det, &
+                                     block(a_blk_no)%xv, block(b_blk_no)%xv)
+      end do
+      do j=1,size(intfr)
+         call print_interface_detail("vy", intfr(j)%counteryv, intfr(j)%vy_interface_det, &
+                                     block(a_blk_no)%yv, block(b_blk_no)%yv)
+      end do
+      do j=1,size(intfr)
+          call print_interface_detail("vz", intfr(j)%counterzv, intfr(j)%vz_interface_det, &
+                                      block(a_blk_no)%zv, block(b_blk_no)%zv)
+        end do
         DO j=1,size(intfr)
-        print*,'**********************px***************************'
-        DO i=1,intfr(j)%counterxp
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'px', i, (intfr(j)%px_interface_det(k,i), k=1,3),&
-                                      block(a_blk_no)%xp(intfr(j)%px_interface_det(1,i)), &
-                                      (block(b_blk_no)%xp(intfr(j)%px_interface_det(k,i)), k=2,3)
+          call print_interface_detail("wx", intfr(j)%counterxw, intfr(j)%wx_interface_det, &
+                                      block(a_blk_no)%xw, block(b_blk_no)%xw)
         end do
+        do j=1,size(intfr)
+           call print_interface_detail("wy", intfr(j)%counteryw, intfr(j)%wy_interface_det, &
+                                       block(a_blk_no)%yw, block(b_blk_no)%yw)
         end do
-        DO j=1,size(intfr)
-        print*,'**********************py***************************'
-        DO i=1,intfr(j)%counteryp
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'py', i, (intfr(j)%py_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%yp(intfr(j)%py_interface_det(1,i)), &
-                                      (block(b_blk_no)%yp(intfr(j)%py_interface_det(k,i)), k=2,3)
+        do j=1,size(intfr)
+           call print_interface_detail("wz", intfr(j)%counterzw, intfr(j)%wz_interface_det, &
+                                       block(a_blk_no)%zw, block(b_blk_no)%zw)
         end do
-        end do
-        DO j=1,size(intfr)
-        print*,'**********************pz***************************'
-        DO i=1,intfr(j)%counterzp
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'pz', i, (intfr(j)%pz_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%zp(intfr(j)%pz_interface_det(1,i)), &
-                                      (block(b_blk_no)%zp(intfr(j)%pz_interface_det(k,i)), k=2,3)
-        end do
-        end do
+  end do
 
-        DO j=1,size(intfr)
-        print*,'**********************ux***************************'
-        DO i=1,intfr(j)%counterxu
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'ux', i, (intfr(j)%ux_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%xu(intfr(j)%ux_interface_det(1,i)), &
-                                      (block(b_blk_no)%xu(intfr(j)%ux_interface_det(k,i)), k=2,3)
-        end do
-        end do
-        DO j=1,size(intfr)
-        print*,'**********************uy***************************'
-        DO i=1,intfr(j)%counteryu
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'uy', i, (intfr(j)%uy_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%yu(intfr(j)%uy_interface_det(1,i)), &
-                                      (block(b_blk_no)%yu(intfr(j)%uy_interface_det(k,i)), k=2,3)
-        end do
-        end do
-        DO j=1,size(intfr)
-        print*,'**********************uz***************************'
-        DO i=1,intfr(j)%counterzu
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'uz', i, (intfr(j)%uz_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%zu(intfr(j)%uz_interface_det(1,i)), &
-                                      (block(b_blk_no)%zu(intfr(j)%uz_interface_det(k,i)), k=2,3)
-        end do
-        end do
-
-        DO j=1,size(intfr)
-        print*,'**********************vx***************************'
-        DO i=1,intfr(j)%counterxv
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'vx', i, (intfr(j)%vx_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%xv(intfr(j)%vx_interface_det(1,i)), &
-                                      (block(b_blk_no)%xv(intfr(j)%vx_interface_det(k,i)), k=2,3)
-        end do
-        end do
-        DO j=1,size(intfr)
-        print*,'**********************vy***************************'
-        DO i=1,intfr(j)%counteryv
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'vy', i, (intfr(j)%vy_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%yv(intfr(j)%vy_interface_det(1,i)), &
-                                      (block(b_blk_no)%yv(intfr(j)%vy_interface_det(k,i)), k=2,3)
-        end do
-        end do
-        DO j=1,size(intfr)
-        print*,'**********************vz***************************'
-        DO i=1,intfr(j)%counterzv
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'vz', i, (intfr(j)%vz_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%zv(intfr(j)%vz_interface_det(1,i)), &
-                                      (block(b_blk_no)%zv(intfr(j)%vz_interface_det(k,i)), k=2,3)
-        end do
-        end do
-
-
-        DO j=1,size(intfr)
-        print*,'**********************wx***************************'
-        DO i=1,intfr(j)%counterxw
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'wx', i, (intfr(j)%wx_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%xw(intfr(j)%wx_interface_det(1,i)), &
-                                      (block(b_blk_no)%xw(intfr(j)%wx_interface_det(k,i)), k=2,3)
-        end do
-        end do
-        DO j=1,size(intfr)
-        print*,'**********************wy***************************'
-        DO i=1,intfr(j)%counteryw
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'wy', i, (intfr(j)%wy_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%yw(intfr(j)%wy_interface_det(1,i)), &
-                                      (block(b_blk_no)%yw(intfr(j)%wy_interface_det(k,i)), k=2,3)
-        end do
-        end do
-        DO j=1,size(intfr)
-        print*,'**********************wz***************************'
-        DO i=1,intfr(j)%counterzw
-          WRITE(*,'(A3,I5,3I5,3F8.5)') 'wz', i, (intfr(j)%wz_interface_det(k,i), k=1,3), &
-                                      block(a_blk_no)%zw(intfr(j)%wz_interface_det(1,i)), &
-                                      (block(b_blk_no)%zw(intfr(j)%wz_interface_det(k,i)), k=2,3)
-        end do
-        end do
-        endif
-        ENDDO
-
-        end subroutine change_block_interface
+end subroutine change_block_interface
 
         SUBROUTINE cellCount_solid_coarse(blk)
 

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -1475,202 +1475,123 @@ blk%fluidCellCount = flcnt
 
         SUBROUTINE change_block_interface
 
-        INTEGER(int64) :: i,j,g, a_blk_no, b_blk_no, factor
-
-
+        INTEGER(int64) :: i,j,g, a_blk_no, b_blk_no, factor,k,increment
 
         DO g=1,intflines
         a_blk_no=intfr(g)%a_blk
         b_blk_no=intfr(g)%b_blk
-         factor=intfr(g)%b_msh/intfr(g)%a_msh
+        factor=intfr(g)%b_msh/intfr(g)%a_msh
+        increment = block(b_blk_no)%move_amtx/factor
         if ( block(b_blk_no)% move_check == 1) then
-        DO j=1,intfr(g)%counterxp
 
-        intfr(g)%px_interface_det(1,j) = intfr(g)%px_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amtx/factor)
-        ENDDO
-        DO j=1,intfr(g)%counterxu
+        intfr(g)%px_interface_det(1,1:intfr(g)%counterxp) =&
+              intfr(g)%px_interface_det(1,1:intfr(g)%counterxp) + increment
 
-        intfr(g)%ux_interface_det(1,j) = intfr(g)%ux_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amtx/factor)
+        intfr(g)%ux_interface_det(1,1:intfr(g)%counterxu) =&
+              intfr(g)%ux_interface_det(1,1:intfr(g)%counterxu) + increment
 
-        ENDDO
-        DO j=1,intfr(g)%counterxv
+        intfr(g)%vx_interface_det(1,1:intfr(g)%counterxv) =&
+              intfr(g)%vx_interface_det(1,1:intfr(g)%counterxv) + increment
 
-        intfr(g)%vx_interface_det(1,j) = intfr(g)%vx_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amtx/factor)
+        intfr(g)%wx_interface_det(1,1:intfr(g)%counterxw) =&
+              intfr(g)%wx_interface_det(1,1:intfr(g)%counterxw) + increment
 
-        ENDDO
-        DO j=1,intfr(g)%counterxw
+        intfr(g)%py_interface_det(1,1:intfr(g)%counteryp) =&
+              intfr(g)%py_interface_det(1,1:intfr(g)%counteryp) + increment
 
-        intfr(g)%wx_interface_det(1,j) = intfr(g)%wx_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amtx/factor)
+        intfr(g)%uy_interface_det(1,1:intfr(g)%counteryu) =&
+              intfr(g)%uy_interface_det(1,1:intfr(g)%counteryu) + increment
 
-        ENDDO
+        intfr(g)%vy_interface_det(1,1:intfr(g)%counteryv) =&
+              intfr(g)%vy_interface_det(1,1:intfr(g)%counteryv) + increment
 
-        DO j=1,intfr(g)%counteryp
+        intfr(g)%wy_interface_det(1,1:intfr(g)%counteryw) =&
+              intfr(g)%wy_interface_det(1,1:intfr(g)%counteryw) + increment
 
-        intfr(g)%py_interface_det(1,j) = intfr(g)%py_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amty/factor)
-        ENDDO
-        DO j=1,intfr(g)%counteryu
+        intfr(g)%pz_interface_det(1,1:intfr(g)%counterzp) =&
+              intfr(g)%pz_interface_det(1,1:intfr(g)%counterzp) + increment
 
-        intfr(g)%uy_interface_det(1,j) = intfr(g)%uy_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amty/factor)
+        intfr(g)%uz_interface_det(1,1:intfr(g)%counterzu) =&
+              intfr(g)%uz_interface_det(1,1:intfr(g)%counterzu) + increment
 
-        ENDDO
-        DO j=1,intfr(g)%counteryv
+        intfr(g)%vz_interface_det(1,1:intfr(g)%counterzv) =&
+              intfr(g)%vz_interface_det(1,1:intfr(g)%counterzv) + increment
 
-        intfr(g)%vy_interface_det(1,j) = intfr(g)%vy_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amty/factor)
+        intfr(g)%wz_interface_det(1,1:intfr(g)%counterzw) =&
+              intfr(g)%wz_interface_det(1,1:intfr(g)%counterzw) + increment
 
-        ENDDO
-        DO j=1,intfr(g)%counteryw
-
-        intfr(g)%wy_interface_det(1,j) = intfr(g)%wy_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amty/factor)
-
-        ENDDO
-        DO j=1,intfr(g)%counterzp
-
-        intfr(g)%pz_interface_det(1,j) = intfr(g)%pz_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amtz/factor)
-        ENDDO
-        DO j=1,intfr(g)%counterzu
-
-        intfr(g)%uz_interface_det(1,j) = intfr(g)%uz_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amtz/factor)
-
-        ENDDO
-        DO j=1,intfr(g)%counterzv
-
-        intfr(g)%vz_interface_det(1,j) = intfr(g)%vz_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amtz/factor)
-
-        ENDDO
-        DO j=1,intfr(g)%counterzw
-
-        intfr(g)%wz_interface_det(1,j) = intfr(g)%wz_interface_det(1,j) &
-                                         + (block(b_blk_no)%move_amtz/factor)
-
-        ENDDO
         DO j=1,intflines
         print*,'**********************px***************************'
         DO i=1,intfr(j)%counterxp
-        WRITE(*,33) 'px', i, &
-                     intfr(j)%px_interface_det(1,i), &
-                     intfr(j)%px_interface_det(2,i), &
-                     intfr(j)%px_interface_det(3,i), &
-                     block(a_blk_no)%xp(intfr(j)%px_interface_det(1,i)), &
-                     block(b_blk_no)%xp(intfr(j)%px_interface_det(2,i)), &
-                     block(b_blk_no)%xp(intfr(j)%px_interface_det(3,i))
- 33       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'px', i, (intfr(j)%px_interface_det(k,i), k=1,3),&
+                                      block(a_blk_no)%xp(intfr(j)%px_interface_det(1,i)), &
+                                      (block(b_blk_no)%xp(intfr(j)%px_interface_det(k,i)), k=2,3)
         end do
         end do
         DO j=1,intfLines
         print*,'**********************py***************************'
         DO i=1,intfr(j)%counteryp
-        WRITE(*,133) 'py', i, &
-                     intfr(j)%py_interface_det(1,i), &
-                     intfr(j)%py_interface_det(2,i), &
-                     intfr(j)%py_interface_det(3,i), &
-                     block(a_blk_no)%yp(intfr(j)%py_interface_det(1,i)), &
-                     block(b_blk_no)%yp(intfr(j)%py_interface_det(2,i)), &
-                     block(b_blk_no)%yp(intfr(j)%py_interface_det(3,i))
- 133       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'py', i, (intfr(j)%py_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%yp(intfr(j)%py_interface_det(1,i)), &
+                                      (block(b_blk_no)%yp(intfr(j)%py_interface_det(k,i)), k=2,3)
         end do
         end do
         DO j=1,intflines
         print*,'**********************pz***************************'
         DO i=1,intfr(j)%counterzp
-        WRITE(*,933) 'pz', i, &
-                     intfr(j)%pz_interface_det(1,i), &
-                     intfr(j)%pz_interface_det(2,i), &
-                     intfr(j)%pz_interface_det(3,i), &
-                     block(a_blk_no)%zp(intfr(j)%pz_interface_det(1,i)), &
-                     block(b_blk_no)%zp(intfr(j)%pz_interface_det(2,i)), &
-                     block(b_blk_no)%zp(intfr(j)%pz_interface_det(3,i))
- 933       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'pz', i, (intfr(j)%pz_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%zp(intfr(j)%pz_interface_det(1,i)), &
+                                      (block(b_blk_no)%zp(intfr(j)%pz_interface_det(k,i)), k=2,3)
         end do
         end do
 
         DO j=1,intflines
         print*,'**********************ux***************************'
         DO i=1,intfr(j)%counterxu
-        WRITE(*,331) 'ux', i, &
-                     intfr(j)%ux_interface_det(1,i), &
-                     intfr(j)%ux_interface_det(2,i), &
-                     intfr(j)%ux_interface_det(3,i),  &
-                     block(a_blk_no)%xu(intfr(j)%ux_interface_det(1,i)), &
-                     block(b_blk_no)%xu(intfr(j)%ux_interface_det(2,i)), &
-                     block(b_blk_no)%xu(intfr(j)%ux_interface_det(3,i))
- 331       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'ux', i, (intfr(j)%ux_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%xu(intfr(j)%ux_interface_det(1,i)), &
+                                      (block(b_blk_no)%xu(intfr(j)%ux_interface_det(k,i)), k=2,3)
         end do
         end do
         DO j=1,intfLines
         print*,'**********************uy***************************'
         DO i=1,intfr(j)%counteryu
-        WRITE(*,1331) 'uy', i, &
-                     intfr(j)%uy_interface_det(1,i), &
-                     intfr(j)%uy_interface_det(2,i), &
-                     intfr(j)%uy_interface_det(3,i),  &
-                     block(a_blk_no)%yu(intfr(j)%uy_interface_det(1,i)), &
-                     block(b_blk_no)%yu(intfr(j)%uy_interface_det(2,i)), &
-                     block(b_blk_no)%yu(intfr(j)%uy_interface_det(3,i))
- 1331       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'uy', i, (intfr(j)%uy_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%yu(intfr(j)%uy_interface_det(1,i)), &
+                                      (block(b_blk_no)%yu(intfr(j)%uy_interface_det(k,i)), k=2,3)
         end do
         end do
         DO j=1,intfLines
         print*,'**********************uz***************************'
         DO i=1,intfr(j)%counterzu
-        WRITE(*,91331) 'uz', i, &
-                     intfr(j)%uz_interface_det(1,i), &
-                     intfr(j)%uz_interface_det(2,i), &
-                     intfr(j)%uz_interface_det(3,i),  &
-                     block(a_blk_no)%zu(intfr(j)%uz_interface_det(1,i)), &
-                     block(b_blk_no)%zu(intfr(j)%uz_interface_det(2,i)), &
-                     block(b_blk_no)%zu(intfr(j)%uz_interface_det(3,i))
-91331       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'uz', i, (intfr(j)%uz_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%zu(intfr(j)%uz_interface_det(1,i)), &
+                                      (block(b_blk_no)%zu(intfr(j)%uz_interface_det(k,i)), k=2,3)
         end do
         end do
 
         DO j=1,intflines
         print*,'**********************vx***************************'
         DO i=1,intfr(j)%counterxv
-        WRITE(*,332) 'vx', i, &
-                     intfr(j)%vx_interface_det(1,i), &
-                     intfr(j)%vx_interface_det(2,i), &
-                     intfr(j)%vx_interface_det(3,i),  &
-                     block(a_blk_no)%xv(intfr(j)%vx_interface_det(1,i)), &
-                     block(b_blk_no)%xv(intfr(j)%vx_interface_det(2,i)), &
-                     block(b_blk_no)%xv(intfr(j)%vx_interface_det(3,i))
- 332       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'vx', i, (intfr(j)%vx_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%xv(intfr(j)%vx_interface_det(1,i)), &
+                                      (block(b_blk_no)%xv(intfr(j)%vx_interface_det(k,i)), k=2,3)
         end do
         end do
         DO j=1,intfLines
         print*,'**********************vy***************************'
         DO i=1,intfr(j)%counteryv
-        WRITE(*,1332) 'vy', i, &
-                     intfr(j)%vy_interface_det(1,i), &
-                     intfr(j)%vy_interface_det(2,i), &
-                     intfr(j)%vy_interface_det(3,i),  &
-                     block(a_blk_no)%yv(intfr(j)%vy_interface_det(1,i)), &
-                     block(b_blk_no)%yv(intfr(j)%vy_interface_det(2,i)), &
-                     block(b_blk_no)%yv(intfr(j)%vy_interface_det(3,i))
- 1332       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'vy', i, (intfr(j)%vy_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%yv(intfr(j)%vy_interface_det(1,i)), &
+                                      (block(b_blk_no)%yv(intfr(j)%vy_interface_det(k,i)), k=2,3)
         end do
         end do
         DO j=1,intfLines
         print*,'**********************vz***************************'
         DO i=1,intfr(j)%counterzv
-        WRITE(*,91332) 'vz', i, &
-                     intfr(j)%vz_interface_det(1,i), &
-                     intfr(j)%vz_interface_det(2,i), &
-                     intfr(j)%vz_interface_det(3,i),  &
-                     block(a_blk_no)%zv(intfr(j)%vz_interface_det(1,i)), &
-                     block(b_blk_no)%zv(intfr(j)%vz_interface_det(2,i)), &
-                     block(b_blk_no)%zv(intfr(j)%vz_interface_det(3,i))
-91332       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'vz', i, (intfr(j)%vz_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%zv(intfr(j)%vz_interface_det(1,i)), &
+                                      (block(b_blk_no)%zv(intfr(j)%vz_interface_det(k,i)), k=2,3)
         end do
         end do
 
@@ -1678,40 +1599,25 @@ blk%fluidCellCount = flcnt
         DO j=1,intflines
         print*,'**********************wx***************************'
         DO i=1,intfr(j)%counterxw
-        WRITE(*,3329) 'wx', i, &
-                      intfr(j)%wx_interface_det(1,i), &
-                      intfr(j)%wx_interface_det(2,i), &
-                      intfr(j)%wx_interface_det(3,i), &
-                      block(a_blk_no)%xw(intfr(j)%wx_interface_det(1,i)), &
-                      block(b_blk_no)%xw(intfr(j)%wx_interface_det(2,i)), &
-                      block(b_blk_no)%xw(intfr(j)%wx_interface_det(3,i))
- 3329       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'wx', i, (intfr(j)%wx_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%xw(intfr(j)%wx_interface_det(1,i)), &
+                                      (block(b_blk_no)%xw(intfr(j)%wx_interface_det(k,i)), k=2,3)
         end do
         end do
         DO j=1,intfLines
         print*,'**********************wy***************************'
         DO i=1,intfr(j)%counteryw
-        WRITE(*,13329) 'wy', i, &
-                      intfr(j)%wy_interface_det(1,i), &
-                      intfr(j)%wy_interface_det(2,i), &
-                      intfr(j)%wy_interface_det(3,i), &
-                      block(a_blk_no)%yw(intfr(j)%wy_interface_det(1,i)), &
-                      block(b_blk_no)%yw(intfr(j)%wy_interface_det(2,i)), &
-                      block(b_blk_no)%yw(intfr(j)%wy_interface_det(3,i))
-13329       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'wy', i, (intfr(j)%wy_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%yw(intfr(j)%wy_interface_det(1,i)), &
+                                      (block(b_blk_no)%yw(intfr(j)%wy_interface_det(k,i)), k=2,3)
         end do
         end do
         DO j=1,intfLines
         print*,'**********************wz***************************'
         DO i=1,intfr(j)%counterzw
-        WRITE(*,93329) 'wz', i, &
-                      intfr(j)%wz_interface_det(1,i), &
-                      intfr(j)%wz_interface_det(2,i), &
-                      intfr(j)%wz_interface_det(3,i), &
-                      block(a_blk_no)%zw(intfr(j)%wz_interface_det(1,i)), &
-                      block(b_blk_no)%zw(intfr(j)%wz_interface_det(2,i)), &
-                      block(b_blk_no)%zw(intfr(j)%wz_interface_det(3,i))
-93329       FORMAT(A3,I5,3I5,3F8.5)
+          WRITE(*,'(A3,I5,3I5,3F8.5)') 'wz', i, (intfr(j)%wz_interface_det(k,i), k=1,3), &
+                                      block(a_blk_no)%zw(intfr(j)%wz_interface_det(1,i)), &
+                                      (block(b_blk_no)%zw(intfr(j)%wz_interface_det(k,i)), k=2,3)
         end do
         end do
         endif

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -1385,7 +1385,7 @@ blk%fluidCellCount = flcnt
 
 SUBROUTINE change_block_interface
 
-  INTEGER(int64) :: i,j,g, a_blk_no, b_blk_no, factor,increment
+  INTEGER(int64) :: j,g, a_blk_no, b_blk_no, factor,increment
 
   do g=1,size(intfr)
      b_blk_no=intfr(g)%b_blk

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -1392,8 +1392,8 @@ SUBROUTINE change_block_interface
      if ( block(b_blk_no)% move_check /= 1) cycle
      a_blk_no=intfr(g)%a_blk
      factor=intfr(g)%b_msh/intfr(g)%a_msh
-     increment = block(b_blk_no)%move_amtx/factor
 
+     increment = block(b_blk_no)%move_amtx/factor
      intfr(g)%px_interface_det(1,1:intfr(g)%counterxp) =&
              intfr(g)%px_interface_det(1,1:intfr(g)%counterxp) + increment
 
@@ -1405,6 +1405,7 @@ SUBROUTINE change_block_interface
 
      intfr(g)%wx_interface_det(1,1:intfr(g)%counterxw) =&
              intfr(g)%wx_interface_det(1,1:intfr(g)%counterxw) + increment
+
      increment = block(b_blk_no)%move_amty/factor
      intfr(g)%py_interface_det(1,1:intfr(g)%counteryp) =&
              intfr(g)%py_interface_det(1,1:intfr(g)%counteryp) + increment
@@ -1417,6 +1418,7 @@ SUBROUTINE change_block_interface
 
      intfr(g)%wy_interface_det(1,1:intfr(g)%counteryw) =&
              intfr(g)%wy_interface_det(1,1:intfr(g)%counteryw) + increment
+
      increment = block(b_blk_no)%move_amtz/factor
      intfr(g)%pz_interface_det(1,1:intfr(g)%counterzp) =&
              intfr(g)%pz_interface_det(1,1:intfr(g)%counterzp) + increment

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -1385,7 +1385,7 @@ blk%fluidCellCount = flcnt
 
 SUBROUTINE change_block_interface
 
-  INTEGER(int64) :: i,j,g, a_blk_no, b_blk_no, factor,k,increment
+  INTEGER(int64) :: i,j,g, a_blk_no, b_blk_no, factor,increment
 
   do g=1,size(intfr)
      b_blk_no=intfr(g)%b_blk

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -1405,7 +1405,7 @@ SUBROUTINE change_block_interface
 
      intfr(g)%wx_interface_det(1,1:intfr(g)%counterxw) =&
              intfr(g)%wx_interface_det(1,1:intfr(g)%counterxw) + increment
-
+     increment = block(b_blk_no)%move_amty/factor
      intfr(g)%py_interface_det(1,1:intfr(g)%counteryp) =&
              intfr(g)%py_interface_det(1,1:intfr(g)%counteryp) + increment
 
@@ -1417,7 +1417,7 @@ SUBROUTINE change_block_interface
 
      intfr(g)%wy_interface_det(1,1:intfr(g)%counteryw) =&
              intfr(g)%wy_interface_det(1,1:intfr(g)%counteryw) + increment
-
+     increment = block(b_blk_no)%move_amtz/factor
      intfr(g)%pz_interface_det(1,1:intfr(g)%counterzp) =&
              intfr(g)%pz_interface_det(1,1:intfr(g)%counterzp) + increment
 


### PR DESCRIPTION
The purpose of this PR is to refactor change block interface, by rewriting the do loops which run over elements as a single line, and utilise print_interface_detail to print the details of the interface. The motivation of this change is to reduce the overall number of lines in the code.