### PR TITLE
Make findtscells run on GPU

### DIFF
--- a/src/Search.F90
+++ b/src/Search.F90
@@ -436,6 +436,7 @@ SUBROUTINE tagging_th_core(blk)
      SUBROUTINE findTScells(blk)
        type(Block_t), intent(inout) :: blk
         INTEGER            :: i, j, k, i1, j1, k1, iPt1, m, n, tscnt
+        integer :: idx
         !$acc parallel loop collapse(3) default(present)
                  DO k = 2, blk%nz+1
                  DO j = 2, blk%ny+1
@@ -478,16 +479,21 @@ SUBROUTINE tagging_th_core(blk)
         ALLOCATE(blk%TSIndexPtr(blk%TSCellCount,3))
 
         iPt1 = 0
+        !$acc parallel loop collapse(3) private(idx)
         DO k=1,blk%nz+3
            DO j=1,blk%ny+3
               DO i=1,blk%nx+3
                  IF (blk%cell2(i,j,k)==2) THEN
+                    !$acc atomic capture
                     iPt1 = iPt1 + 1
-                    blk%TSIndexPtr(iPt1, :) = [i, j, k]
+                    idx = iPt1
+                    !$acc end atomic
+                    blk%TSIndexPtr(idx, :) = [i, j, k]
                  ENDIF
               END DO
            END DO
         END DO
+        !$acc end parallel loop
 
         ALLOCATE(&
           blk%u2_ghost(blk%TSCellCount),  &


### PR DESCRIPTION
This is one of the remaining subroutines that isn't fully running on the GPU (see screenshot). This should be faster than looping through every cell on the CPU.

<img width="1596" height="1009" alt="image" src="https://github.com/user-attachments/assets/a43f9811-939b-4779-ad54-a91d54a6e467" />
