### PR TITLE
Tagging th move blk argument

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -168,7 +168,9 @@
             CALL computeSurfaceNorm(block(g))
          end do
            print*,2
-           CALL tagging_th_move
+         do g=blk_start, size(block)
+           CALL tagging_th_move(block(g), g)
+         end do
         do g=blk_start, size(block)
            CALL selectiveRetagging_th(block(g))
         end do

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -418,20 +418,16 @@ SUBROUTINE tagging_th_core(blk)
         INTEGER(int64), intent(in) :: id
         integer(int64) :: g
 
-        if (blk%move_check == 1) then
-           call tagging_th_core(blk)
-        endif
+        if (blk%move_check /= 1) return
+        call tagging_th_core(blk)
 
         DO g=1, size(intfr)
-           ! Find the interface which this block corresponds to. We
-           ! check if this is the right interface by skipping over
-           ! interfaces where the b_blk is not this one.
+          ! Find the interface which this block corresponds to. We
+          ! check if this is the right interface by skipping over
+          ! interfaces where the b_blk is not this one.
           if (intfr(g)%b_blk /= id) cycle
-
-          if (blk%move_check == 1) then
-            call fineUpdate_mv(g)
-            call fineUpdate_bd_mv(g)
-          endif
+          call fineUpdate_mv(g)
+          call fineUpdate_bd_mv(g)
         ENDDO
      END SUBROUTINE tagging_th_move
 

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -423,11 +423,9 @@ SUBROUTINE tagging_th_core(blk)
         endif
 
         DO g=1, size(intfr)
-           ! Find the interface which this block corresponds to. There
-           ! is an assumption here that each block only interfaces to
-           ! the coarse block. We check if this is the right interface
-           ! by skipping over interfaces where the b_blk is not this
-           ! one.
+           ! Find the interface which this block corresponds to. We
+           ! check if this is the right interface by skipping over
+           ! interfaces where the b_blk is not this one.
           if (intfr(g)%b_blk /= id) cycle
 
           if (blk%move_check == 1) then

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -412,24 +412,28 @@ SUBROUTINE tagging_th_core(blk)
 
      END SUBROUTINE tagging_th
 
-     SUBROUTINE tagging_th_move
+     SUBROUTINE tagging_th_move(blk, id)
 
-        INTEGER(int64) :: g
-        INTEGER            :: a_blk_no, b_blk_no
+        type(Block_t), intent(inout) :: blk
+        INTEGER(int64), intent(in) :: id
+        integer(int64) :: g
 
-        DO g=blk_start,size(block)
-        if ( block(g)%move_check == 1)then
-           call tagging_th_core(block(g))
+        if (blk%move_check == 1) then
+           call tagging_th_core(blk)
         endif
-        ENDDO
-        DO g=1,size(intfr)
-        a_blk_no=intfr(g)%a_blk
-        b_blk_no=intfr(g)%b_blk
 
-        if ( block(b_blk_no)%move_check == 1)then
-       call fineUpdate_mv(g)
-       call fineUpdate_bd_mv(g)
-        endif
+        DO g=1, size(intfr)
+           ! Find the interface which this block corresponds to. There
+           ! is an assumption here that each block only interfaces to
+           ! the coarse block. We check if this is the right interface
+           ! by skipping over interfaces where the b_blk is not this
+           ! one.
+          if (intfr(g)%b_blk /= id) cycle
+
+          if (blk%move_check == 1) then
+            call fineUpdate_mv(g)
+            call fineUpdate_bd_mv(g)
+          endif
         ENDDO
      END SUBROUTINE tagging_th_move
 


### PR DESCRIPTION
Adds the `blk` (and `id`) argument to `tagging_th_move`. I think this is the first one where we check that the interface corresponds to this block in this way but it will be a somewhat common practice once we get everything implemented for MPI.

For #165 