### PR TITLE
Remove fail fast=false ci

### DIFF
--- a/.github/workflows/fortitude-linting.yml
+++ b/.github/workflows/fortitude-linting.yml
@@ -17,8 +17,6 @@ jobs:
     name: Fortitude-Lint
     runs-on: [ubuntu-latest]
     if: github.event.pull_request.draft == false
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -25,7 +25,6 @@ jobs:
     env:
       FPM_FFLAGS: ${{ matrix.toolchain.FPM_FFLAGS }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         toolchain:


### PR DESCRIPTION
By removing fail-fast = false, we will return to the default value of true (see https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast for details about fail-fast). This will make it so that if one job fails in the ci, then all other jobs in the matrix fail too. The linter workflow only has one job, but thought I'd use this PR to remove it there too since its pointless being defined false there.