### PR TITLE
MPI: Add first MPI calls to CoarseInterp

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 auto-executables = true
 auto-tests = true
 auto-examples = true
-external-modules = ["hdf5", "openacc"]
+external-modules = ["hdf5", "openacc", "mpi_f08"]
 
 [preprocess]
 cpp.macros = ["USE_HDF5=0"]

--- a/src/CoarseInterp.f90
+++ b/src/CoarseInterp.f90
@@ -2,6 +2,9 @@ module biocfd_coarse_update
   use, intrinsic :: iso_fortran_env, only: dp => real64
   use global, only : block, intfr
   use biocfd_interpolation, only: bilinear_interpolation, linear_interpolation
+#ifdef BIOCFD_MPI
+  use mpi_f08
+#endif
 
   implicit none
   private
@@ -15,9 +18,49 @@ subroutine coarseUpdate
         INTEGER :: st_idy, en_idy
         INTEGER :: st_idz, en_idz
 
+#ifdef BIOCFD_MPI
+        integer :: rank, num_proc, ierror, token
+        call MPI_Comm_size(MPI_COMM_WORLD, num_proc, ierror)
+        call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+
+        ! TN: I *think* that this interpolation needs to essentially
+        ! happen serially across ranks. The idea is that rank 0 will
+        ! run first, then update block(1) on rank 1 and tell rank 1 it
+        ! can start. Rank 1 would then update the block on rank 2 and
+        ! tell rank 2 it can start. This process will repeat up to
+        ! rank n. Once rank n finishes we broadcast the block(1)
+        ! arrays to all ranks so that everything is up to date.
+        !
+        ! We don't wait for anything if we are on rank 0 and just get
+        ! started
+        if (rank /= 0) then
+          ! This essentially acts as a barrier in that rank n wont
+          ! start until rank n-1 has finished. Assumes that a_blk number is always 1
+          call MPI_Recv(block(1)%p, size(block(1)%p), MPI_DOUBLE_PRECISION, rank-1, 0, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierror)
+          call MPI_Recv(block(1)%u, size(block(1)%u), MPI_DOUBLE_PRECISION, rank-1, 0, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierror)
+          call MPI_Recv(block(1)%v, size(block(1)%v), MPI_DOUBLE_PRECISION, rank-1, 0, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierror)
+          call MPI_Recv(block(1)%w, size(block(1)%w), MPI_DOUBLE_PRECISION, rank-1, 0, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierror)
+        end if
+
+#endif
+
         DO g=1,size(intfr)
         a_blk_no=intfr(g)%a_blk
         b_blk_no=intfr(g)%b_blk
+
+#ifdef BIOCFD_MPI
+           if (.not. allocated(block(b_blk_no)%p)) then
+               ! If this array isn't allocated we aren't on the right
+               ! rank to deal with this so keep going until we find
+               ! one that is on this rank
+               cycle
+           end if
+#endif
+
         st_idx=block(b_blk_no)%cintp
         en_idx=intfr(g)%counterxp-block(b_blk_no)%cintp
         st_idy=block(b_blk_no)%cintp
@@ -127,6 +170,36 @@ subroutine coarseUpdate
         enddo
         enddo
         ENDDO
+
+#ifdef BIOCFD_MPI
+        ! We have no finished processing the p, u, v, and w arrays on
+        ! rank n - send these arrays to rank n+1 to continue, unless
+        ! we are the last rank, in which case we need will broadcast
+        ! the updated array to all ranks (this is maybe something that
+        ! can be optimised as we might not need everything to be up to
+        ! date here)
+        if (rank /= (num_proc-1)) then
+          call MPI_Send(block(1)%p, size(block(1)%p), MPI_DOUBLE_PRECISION, rank+1, 0, &
+                        MPI_COMM_WORLD, ierror)
+          call MPI_Send(block(1)%u, size(block(1)%u), MPI_DOUBLE_PRECISION, rank+1, 0, &
+                        MPI_COMM_WORLD, ierror)
+          call MPI_Send(block(1)%v, size(block(1)%v), MPI_DOUBLE_PRECISION, rank+1, 0, &
+                        MPI_COMM_WORLD, ierror)
+          call MPI_Send(block(1)%w, size(block(1)%w), MPI_DOUBLE_PRECISION, rank+1, 0, &
+                        MPI_COMM_WORLD, ierror)
+        end if
+
+        ! This will block everything until the last rank is done
+        call MPI_Bcast(block(1)%p, size(block(1)%p), MPI_DOUBLE_PRECISION, num_proc-1, &
+                       MPI_COMM_WORLD)
+        call MPI_Bcast(block(1)%u, size(block(1)%u), MPI_DOUBLE_PRECISION, num_proc-1, &
+                       MPI_COMM_WORLD)
+        call MPI_Bcast(block(1)%v, size(block(1)%v), MPI_DOUBLE_PRECISION, num_proc-1, &
+                       MPI_COMM_WORLD)
+        call MPI_Bcast(block(1)%w, size(block(1)%w), MPI_DOUBLE_PRECISION, num_proc-1, &
+                       MPI_COMM_WORLD)
+#endif
+
         end subroutine coarseUpdate
 
         subroutine coarseUpdate_newv
@@ -136,9 +209,38 @@ subroutine coarseUpdate
         INTEGER :: st_idy, en_idy
         INTEGER :: st_idz, en_idz
 
+#ifdef BIOCFD_MPI
+        integer :: rank, num_proc, ierror, token
+        call MPI_Comm_size(MPI_COMM_WORLD, num_proc, ierror)
+        call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+        ! We don't wait for anything if we are on rank 0 and just get
+        ! started
+        if (rank /= 0) then
+          ! This essentially acts as a barrier in that rank n wont
+          ! start until rank n-1 has finished. Assumes that a_blk number is always 1
+          call MPI_Recv(block(1)%ut, size(block(1)%ut), MPI_DOUBLE_PRECISION, rank-1, 0, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierror)
+          call MPI_Recv(block(1)%vt, size(block(1)%vt), MPI_DOUBLE_PRECISION, rank-1, 0, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierror)
+          call MPI_Recv(block(1)%wt, size(block(1)%wt), MPI_DOUBLE_PRECISION, rank-1, 0, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierror)
+        end if
+
+#endif
+
         DO g=1,size(intfr)
         a_blk_no=intfr(g)%a_blk
         b_blk_no=intfr(g)%b_blk
+
+#ifdef BIOCFD_MPI
+        if (.not. allocated(block(b_blk_no)%ut)) then
+            ! If this array isn't allocated we aren't on the right
+            ! rank to deal with this so keep going until we find
+            ! one that is on this rank
+            cycle
+        end if
+#endif
+
         st_idx=block(b_blk_no)%cintp
         en_idx=intfr(g)%counterxu-block(b_blk_no)%cintp
         st_idy=block(b_blk_no)%cintp
@@ -220,6 +322,26 @@ subroutine coarseUpdate
         enddo
         enddo
         ENDDO
+
+#ifdef BIOCFD_MPI
+        if (rank /= (num_proc-1)) then
+          call MPI_Send(block(1)%ut, size(block(1)%ut), MPI_DOUBLE_PRECISION, rank+1, 0, &
+                        MPI_COMM_WORLD, ierror)
+          call MPI_Send(block(1)%vt, size(block(1)%vt), MPI_DOUBLE_PRECISION, rank+1, 0, &
+                        MPI_COMM_WORLD, ierror)
+          call MPI_Send(block(1)%wt, size(block(1)%wt), MPI_DOUBLE_PRECISION, rank+1, 0, &
+                        MPI_COMM_WORLD, ierror)
+        end if
+
+        ! This will block everything until the last rank is done
+        call MPI_Bcast(block(1)%ut, size(block(1)%ut), MPI_DOUBLE_PRECISION, num_proc-1, &
+                       MPI_COMM_WORLD)
+        call MPI_Bcast(block(1)%vt, size(block(1)%vt), MPI_DOUBLE_PRECISION, num_proc-1, &
+                       MPI_COMM_WORLD)
+        call MPI_Bcast(block(1)%wt, size(block(1)%wt), MPI_DOUBLE_PRECISION, num_proc-1, &
+                       MPI_COMM_WORLD)
+#endif
+
         end subroutine coarseUpdate_newv
         subroutine coarseUpdate_pc
 
@@ -230,10 +352,40 @@ subroutine coarseUpdate
         INTEGER :: st_idy, en_idy
         INTEGER :: st_idz, en_idz
 
+#ifdef BIOCFD_MPI
+        integer :: rank, num_proc, ierror, token
+        call MPI_Comm_size(MPI_COMM_WORLD, num_proc, ierror)
+        call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+
+        ! We don't wait for anything if we are on rank 0 and just get
+        ! started
+        if (rank /= 0) then
+          ! This essentially acts as a barrier in that rank n wont
+          ! start until rank n-1 has finished. Assumes that a_blk number is always 1
+          call MPI_Recv(block(1)%pc, size(block(1)%pc), MPI_DOUBLE_PRECISION, rank-1, 0, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierror)
+          ! TN: We could consider just doing the copy locally on each rank here
+          call MPI_Recv(block(1)%pco, size(block(1)%pco), MPI_DOUBLE_PRECISION, rank-1, 0, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierror)
+        end if
+
+#endif
+
 
         DO g=1,size(intfr)
         a_blk_no=intfr(g)%a_blk
         b_blk_no=intfr(g)%b_blk
+
+
+#ifdef BIOCFD_MPI
+        if (.not. allocated(block(b_blk_no)%pc)) then
+            ! If this array isn't allocated we aren't on the right
+            ! rank to deal with this so keep going until we find
+            ! one that is on this rank
+            cycle
+        end if
+#endif
+
         st_idx=block(b_blk_no)%cintp
         en_idx=intfr(g)%counterxp-block(b_blk_no)%cintp
         st_idy=block(b_blk_no)%cintp
@@ -266,6 +418,21 @@ subroutine coarseUpdate
         enddo
         enddo
         ENDDO
+
+#ifdef BIOCFD_MPI
+        if (rank /= (num_proc-1)) then
+          call MPI_Send(block(1)%pc, size(block(1)%pc), MPI_DOUBLE_PRECISION, rank+1, 0, &
+                        MPI_COMM_WORLD, ierror)
+          call MPI_Send(block(1)%pco, size(block(1)%pco), MPI_DOUBLE_PRECISION, rank+1, 0, &
+                        MPI_COMM_WORLD, ierror)
+        end if
+
+        ! This will block everything until the last rank is done
+        call MPI_Bcast(block(1)%pc, size(block(1)%pc), MPI_DOUBLE_PRECISION, num_proc-1, &
+                       MPI_COMM_WORLD)
+        call MPI_Bcast(block(1)%pco, size(block(1)%pco), MPI_DOUBLE_PRECISION, num_proc-1, &
+                       MPI_COMM_WORLD)
+#endif
       end subroutine coarseUpdate_pc
 
       !> Perform trilinear interpolation. Implemented as two bilinear

--- a/src/CoarseInterp.f90
+++ b/src/CoarseInterp.f90
@@ -3,7 +3,8 @@ module biocfd_coarse_update
   use global, only : block, intfr
   use biocfd_interpolation, only: bilinear_interpolation, linear_interpolation
 #ifdef BIOCFD_MPI
-  use mpi_f08
+  use mpi_f08, only: MPI_COMM_WORLD, MPI_STATUS_IGNORE, MPI_DOUBLE_PRECISION, &
+       MPI_Comm_size, MPI_Comm_rank, MPI_Send, MPI_Recv, MPI_Bcast
 #endif
 
   implicit none


### PR DESCRIPTION
Getting started with #209. This adds the MPI routines to `CoarseInterp`, just as was done in the MPI R&D branch. Everything should be protected by `BIOCFD_MPI` so all the added code will just be ignored in compilation without that flag 

Note that I've not tested it with this flag, and I'm pretty sure it won't work. I'll have to remind myself how I slowly built up the MPI support in the R&D branch.