### PR TITLE
Add tests for hdf5 module

### DIFF
--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -3,11 +3,12 @@
 ! effectively empty
 #if USE_HDF5 == 1
 module biocfd_hdf5_io
-  use, intrinsic :: iso_fortran_env, only: dp => real64, int8,int16,int32,int64
+  use, intrinsic :: iso_fortran_env, only: dp => real64, int8,int32,int64
   use hdf5, only: hsize_t, hid_t, h5open_f, h5fopen_f, h5fcreate_f, h5lexists_f, &
        h5gcreate_f, h5gopen_f, h5screate_f, h5screate_simple_f, h5dcreate_f, &
        h5dwrite_f, h5dclose_f, h5sclose_f, h5gclose_f, h5fclose_f, h5close_f, &
-       h5F_acc_rdwr_f, H5S_SCALAR_F, H5T_STD_I64LE, h5f_acc_excl_f, h5t_native_double
+       h5F_acc_rdwr_f, H5S_SCALAR_F, H5T_STD_I64LE, h5f_acc_excl_f, h5t_native_double, &
+       h5acreate_f, h5awrite_f, size_t, h5aclose_f, h5sclose_f
   implicit none
 
   private
@@ -27,18 +28,21 @@ contains
     character(len=20) :: dataset_location
     integer(hsize_t),allocatable :: data_dims(:)
     integer(hid_t) :: file_id, dspace_id, dset_id, group_id
+    integer(hid_t) :: attr_id, aspace_id
+    integer(size_t), dimension(1) :: adims
     integer (int32) :: space_rank
-    integer (int8) ::arguments_present
+    integer (int8) :: arguments_present
     integer :: error
     logical :: file_exists, dataset_exists, group_exists
     arguments_present=0
     if (present(scalar_input)) then
       arguments_present = arguments_present + 1
+      adims = [0]
     end if
 
     if (present(array_input_1d)) then
-      if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
+      if(arguments_present /= 0) then
+        error stop "More than one argument present hdf5_write"
       end if
       arguments_present = arguments_present + 1
       allocate(data_dims(1))
@@ -47,8 +51,8 @@ contains
     end if
 
     if (present(array_input_2d)) then
-      if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
+      if(arguments_present /= 0) then
+        error stop "More than one argument present hdf5_write"
       end if
       arguments_present = arguments_present + 1
       allocate(data_dims(2))
@@ -58,8 +62,8 @@ contains
     end if
 
     if (present(array_input_3d)) then
-      if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
+      if(arguments_present /= 0) then
+        error stop "More than one argument present hdf5_write"
       end if
       allocate(data_dims(3))
       data_dims(1) = size(array_input_3d,1)
@@ -71,7 +75,7 @@ contains
     ! Initialize Fortran interface.
     call h5open_f(error)
 
-    inquire(file=trim(filename), exist=file_exists )
+    inquire(file=trim(filename), exist=file_exists)
 
     if (file_exists) then
       ! Open an existing file.
@@ -94,7 +98,7 @@ contains
 
     if (present(scalar_input)) then
       ! Create a scalar dataspace
-      call h5screate_f(H5S_SCALAR_F, dspace_id, error)
+      call h5screate_f(H5S_SCALAR_F, aspace_id, error)
     else
       ! Open dataspace
       call h5screate_simple_f(space_rank,data_dims,dspace_id,error)
@@ -104,8 +108,18 @@ contains
     call h5lexists_f(file_id, trim(dataset_location), dataset_exists, error)
 
     if (.not. dataset_exists) then
-      ! Create dataset if it doesn't exist already
-      call h5dcreate_f(group_id,key,h5t_native_double,dspace_id,dset_id,error)
+      if (present(scalar_input)) then
+        ! Create attribute attached to the group
+        call h5acreate_f(group_id, key, h5t_native_double, aspace_id, attr_id, error)
+      else
+        ! Create dataset if it doesn't exist already
+         call h5dcreate_f(group_id,key,h5t_native_double,dspace_id,dset_id,error)
+      end if
+    end if
+
+    if (present(scalar_input)) then
+       ! Write to dataset
+       call h5awrite_f(attr_id,h5t_native_double, scalar_input, adims, error)
     end if
 
     if (present(array_input_1d)) then
@@ -123,11 +137,16 @@ contains
       call h5dwrite_f(dset_id,h5t_native_double,array_input_3d,data_dims,error)
     end if
 
-    ! Close dataset
-    call h5dclose_f(dset_id,error)
+    if (present(scalar_input)) then
+       call h5aclose_f(attr_id, error)
+       call h5sclose_f(aspace_id, error)
+    else
+       ! Close dataset
+       call h5dclose_f(dset_id,error)
 
-    ! Close dataspace
-    call h5sclose_f(dspace_id, error)
+       ! Close dataspace
+       call h5sclose_f(dspace_id, error)
+    end if
 
     ! Close the group
     call h5gclose_f(group_id, error)
@@ -152,6 +171,8 @@ contains
     character(len=20) :: dataset_location
     integer(hsize_t),allocatable :: data_dims(:)
     integer(hid_t) :: file_id, dspace_id, dset_id, group_id
+    integer(hid_t) :: attr_id, aspace_id
+    integer(size_t), dimension(1) :: adims
     integer (int32) :: space_rank
     integer (int8) :: arguments_present
     integer :: error
@@ -159,11 +180,12 @@ contains
     arguments_present=0
     if (present(scalar_input)) then
       arguments_present = arguments_present + 1
+      adims = [0]
     end if
 
     if (present(array_input_1d)) then
-       if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
+       if(arguments_present /= 0) then
+        error stop "More than one argument present hdf5_write"
       end if
       arguments_present = arguments_present + 1
       allocate(data_dims(1))
@@ -172,8 +194,8 @@ contains
     end if
 
     if (present(array_input_2d)) then
-      if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
+      if(arguments_present /= 0) then
+        error stop "More than one argument present hdf5_write"
       end if
       arguments_present = arguments_present + 1
       allocate(data_dims(2))
@@ -183,8 +205,8 @@ contains
     end if
 
     if (present(array_input_3d)) then
-      if(arguments_present /= 0 ) then
-        error stop 'More than one argument present hdf5_write'
+      if(arguments_present /= 0) then
+        error stop "More than one argument present hdf5_write"
       end if
       allocate(data_dims(3))
       data_dims(1) = size(array_input_3d,1)
@@ -196,14 +218,14 @@ contains
     ! Initialize Fortran interface.
     call h5open_f(error)
 
-    inquire(file=trim(filename), exist=file_exists )
+    inquire(file=trim(filename), exist=file_exists)
 
     if (file_exists) then
       ! Open an existing file.
       call h5fopen_f(trim(filename), h5F_acc_rdwr_f, file_id, error)
     else
       ! Create file requested
-      call h5fcreate_f(trim(filename), h5f_acc_rdwr_f, file_id, error)
+      call h5fcreate_f(trim(filename), h5f_acc_excl_f, file_id, error)
     end if
 
     ! Check if the group exists
@@ -219,7 +241,7 @@ contains
 
     if (present(scalar_input)) then
       ! Create a scalar dataspace
-      call h5screate_f(H5S_SCALAR_F, dspace_id, error)
+      call h5screate_f(H5S_SCALAR_F, aspace_id, error)
     else
       ! Open dataspace
       call h5screate_simple_f(space_rank,data_dims,dspace_id,error)
@@ -229,8 +251,18 @@ contains
      call h5lexists_f(file_id, trim(dataset_location), dataset_exists, error)
 
     if (.not. dataset_exists) then
-      ! Create dataset if it doesn't exist already
-      call h5dcreate_f(group_id,key,H5T_STD_I64LE,dspace_id,dset_id,error)
+      if (present(scalar_input)) then
+        ! Create attribute attached to the group
+        call h5acreate_f(group_id, key, H5T_STD_I64LE, aspace_id, attr_id, error)
+      else
+        ! Create dataset if it doesn't exist already
+         call h5dcreate_f(group_id,key,H5T_STD_I64LE,dspace_id,dset_id,error)
+      end if
+    end if
+
+    if (present(scalar_input)) then
+       ! Write to dataset
+       call h5awrite_f(attr_id,H5T_STD_I64LE, scalar_input, adims, error)
     end if
 
     if (present(array_input_1d)) then
@@ -248,11 +280,16 @@ contains
        call h5dwrite_f(dset_id,H5T_STD_I64LE,array_input_3d,data_dims,error)
     end if
 
-    ! Close dataset
-    call h5dclose_f(dset_id,error)
+    if (present(scalar_input)) then
+       call h5aclose_f(attr_id, error)
+       call h5sclose_f(aspace_id, error)
+    else
+       ! Close dataset
+       call h5dclose_f(dset_id,error)
 
-    ! Close dataspace
-    call h5sclose_f(dspace_id, error)
+       ! Close dataspace
+       call h5sclose_f(dspace_id, error)
+    end if
 
     ! Close the group
     call h5gclose_f(group_id, error)

--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -29,7 +29,7 @@ contains
     integer(hsize_t),allocatable :: data_dims(:)
     integer(hid_t) :: file_id, dspace_id, dset_id, group_id
     integer(hid_t) :: attr_id, aspace_id
-    integer(size_t), dimension(1) :: adims
+    integer(size_t) :: adims(1)
     integer (int32) :: space_rank
     integer (int8) :: arguments_present
     integer :: error
@@ -172,7 +172,7 @@ contains
     integer(hsize_t),allocatable :: data_dims(:)
     integer(hid_t) :: file_id, dspace_id, dset_id, group_id
     integer(hid_t) :: attr_id, aspace_id
-    integer(size_t), dimension(1) :: adims
+    integer(size_t) :: adims(1)
     integer (int32) :: space_rank
     integer (int8) :: arguments_present
     integer :: error

--- a/test/main.f90
+++ b/test/main.f90
@@ -5,6 +5,9 @@ program tester
   use test_interpolation, only: collect_interpolation
   use test_allocate, only: collect_allocate_arrays
   use test_pcor_vcor, only: collect_pcor_vcor
+#if USE_HDF5 == 1
+  use test_hdf5_io, only: collect_hdf5
+#endif
   implicit none
   integer :: stat, is
   type(testsuite_type), allocatable :: testsuites(:)
@@ -16,6 +19,9 @@ program tester
     new_testsuite("search", collect_search), &
     new_testsuite("interpolation", collect_interpolation), &
     new_testsuite("allocate_arrays", collect_allocate_arrays), &
+#if USE_HDF5 == 1
+    new_testsuite("hdf5", collect_hdf5), &
+#endif
     new_testsuite("pcor_vcor", collect_pcor_vcor) &
     ]
 

--- a/test/main.f90
+++ b/test/main.f90
@@ -12,6 +12,9 @@ program tester
   integer :: stat, is
   type(testsuite_type), allocatable :: testsuites(:)
   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+#if USE_HDF5 == 1
+  type(testsuite_type) :: hdf5_tests
+#endif
 
   stat = 0
 
@@ -19,16 +22,18 @@ program tester
     new_testsuite("search", collect_search), &
     new_testsuite("interpolation", collect_interpolation), &
     new_testsuite("allocate_arrays", collect_allocate_arrays), &
-#if USE_HDF5 == 1
-    new_testsuite("hdf5", collect_hdf5), &
-#endif
     new_testsuite("pcor_vcor", collect_pcor_vcor) &
     ]
 
   do is = 1, size(testsuites)
     write(error_unit, fmt) "Testing:", testsuites(is)%name
     call run_testsuite(testsuites(is)%collect, error_unit, stat)
-  end do
+ end do
+
+#if USE_HDF5 == 1
+    hdf5_tests = new_testsuite("hdf5", collect_hdf5)
+    call run_testsuite(hdf5_tests%collect, error_unit, stat)
+#endif
 
   if (stat > 0) then
     write(error_unit, '(i0, 1x, a)') stat, "test(s) failed!"

--- a/test/main.f90
+++ b/test/main.f90
@@ -14,6 +14,7 @@ program tester
   character(len=*), parameter :: fmt = '("#", *(1x, a))'
 #if USE_HDF5 == 1
   type(testsuite_type) :: hdf5_tests
+  integer :: unit
 #endif
 
   stat = 0
@@ -33,6 +34,8 @@ program tester
 #if USE_HDF5 == 1
     hdf5_tests = new_testsuite("hdf5", collect_hdf5)
     call run_testsuite(hdf5_tests%collect, error_unit, stat)
+    open(file="test_output.h5", newunit=unit)
+    close(unit, status="delete")
 #endif
 
   if (stat > 0) then

--- a/test/test_hdf5_io.f90
+++ b/test/test_hdf5_io.f90
@@ -1,0 +1,406 @@
+#if USE_HDF5 == 1
+module test_hdf5_io
+  use, intrinsic :: iso_fortran_env, only: int64, dp =>real64
+  use testdrive, only : error_type, unittest_type, new_unittest, check
+  use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int
+  use hdf5, only: hid_t, hsize_t, h5f_acc_rdonly_f, h5t_std_i64le, &
+       h5t_native_double, h5aread_f, h5dread_f, h5aclose_f, h5aopen_name_f, &
+       h5dclose_f, h5close_f, h5dget_space_f, h5dopen_f, h5fclose_f, &
+       h5fopen_f, h5gclose_f, h5gopen_f, h5open_f, h5sclose_f, &
+       h5sget_simple_extent_dims_f
+  implicit none
+  private
+
+  public :: collect_hdf5
+
+contains
+
+  !> Collect all exported unit tests
+  subroutine collect_hdf5(testsuite)
+    !> Collection of tests
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+    testsuite = [ &
+         new_unittest("hdf5_write_real_3d", test_hdf5_write_real_3d), &
+         new_unittest("hdf5_write_real_2d", test_hdf5_write_real_2d), &
+         new_unittest("hdf5_write_real_1d", test_hdf5_write_real_1d), &
+         new_unittest("hdf5_write_real_scalar", test_hdf5_write_real_scalar), &
+         new_unittest("hdf5_write_int_3d", test_hdf5_write_int_3d), &
+         new_unittest("hdf5_write_int_2d", test_hdf5_write_int_2d), &
+         new_unittest("hdf5_write_int_1d", test_hdf5_write_int_1d), &
+         new_unittest("hdf5_write_int_scalar", test_hdf5_write_int_scalar) &
+         ]
+  end subroutine collect_hdf5
+
+  subroutine test_hdf5_write_real_3d(error)
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+    integer :: i, j, k, error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(3) :: dims, maxdims
+    character(len=*), parameter :: filename = "test_output.h5"
+    character(len=*), parameter :: group = "/test_group"
+    character(len=*), parameter :: key = "3d_real_array"
+
+    real(dp), allocatable :: array3d_read(:,:,:)
+    real(dp), allocatable :: array3d(:,:,:)
+
+    logical :: arrays_equal
+
+    allocate(array3d(4,3,2))
+    do k = 1, 2
+      do j = 1, 3
+        do i = 1, 4
+           array3d(i,j,k) = real(i + 10*j + 100*k, dp)
+        end do
+      end do
+    end do
+
+    call hdf5_write_real(filename=filename, array_input_3d=array3d, key=key, group=group)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(array3d_read(dims(1), dims(2), dims(3)))
+
+    call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, array3d_read, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+    arrays_equal = all(array3d_read == array3d)
+
+    call check(error, .true. , arrays_equal)
+    if (allocated(error)) return
+  end subroutine test_hdf5_write_real_3d
+
+  subroutine test_hdf5_write_real_2d(error)
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+    integer :: j, k, error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(2) :: dims, maxdims
+    character(len=*), parameter :: filename = "test_output.h5"
+    character(len=*), parameter :: group = "/test_group"
+    character(len=*), parameter :: key = "2d_real_array"
+
+    real(dp), allocatable :: array2d_read(:,:)
+    real(dp), allocatable :: array2d(:,:)
+
+    logical :: arrays_equal
+
+    allocate(array2d(3,2))
+    do k = 1, 2
+      do j = 1, 3
+           array2d(j,k) = real(10*j + 100*k, dp)
+      end do
+    end do
+
+    call hdf5_write_real(filename=filename, array_input_2d=array2d, key=key, group=group)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(array2d_read(dims(1), dims(2)))
+
+    call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, array2d_read, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+    arrays_equal = all(array2d_read == array2d)
+
+    call check(error, .true. , arrays_equal)
+    if (allocated(error)) return
+  end subroutine test_hdf5_write_real_2d
+
+  subroutine test_hdf5_write_real_1d(error)
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+    integer :: k, error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(1) :: dims, maxdims
+    character(len=*), parameter :: filename = "test_output.h5"
+    character(len=*), parameter :: group = "/test_group"
+    character(len=*), parameter :: key = "1d_real_array"
+
+    real(dp), allocatable :: array1d_read(:)
+    real(dp), allocatable :: array1d(:)
+
+    logical :: arrays_equal
+
+    allocate(array1d(2))
+    do k = 1, 2
+           array1d(k) = real(100*k, dp)
+    end do
+
+    call hdf5_write_real(filename=filename, array_input_1d=array1d, key=key, group=group)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(array1d_read(dims(1)))
+
+    call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, array1d_read, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+    arrays_equal = all(array1d_read == array1d)
+
+    call check(error, .true. , arrays_equal)
+    if (allocated(error)) return
+  end subroutine test_hdf5_write_real_1d
+
+  subroutine test_hdf5_write_real_scalar(error)
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+    integer :: k, error_hdf5
+    integer(hid_t) :: file_id, group_id, attr_id, attr_space_id
+    INTEGER(HSIZE_T), DIMENSION(1) :: adims
+    character(len=*), parameter :: filename = "test_output.h5"
+    character(len=*), parameter :: group = "/test_group"
+    character(len=*), parameter :: key = "real_scalar"
+
+    real(dp) :: scalar_read
+    real(dp) :: scalar
+
+    adims=1
+    scalar = 20.5_dp
+
+    call hdf5_write_real(filename=filename, scalar_input=scalar, key=key, group=group)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5gopen_f(file_id, group, group_id, error_hdf5)
+
+    call h5aopen_name_f(group_id, key, attr_id, error_hdf5)
+
+
+    call h5aread_f(attr_id, H5T_NATIVE_DOUBLE, scalar_read, adims, error_hdf5)
+
+    call h5aclose_f(attr_id, error_hdf5)
+    call h5gclose_f(group_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+    call check(error, scalar , scalar_read)
+    if (allocated(error)) return
+  end subroutine test_hdf5_write_real_scalar
+
+  subroutine test_hdf5_write_int_3d(error)
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+    integer :: i, j, k, error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(3) :: dims, maxdims
+    character(len=*), parameter :: filename = "test_output.h5"
+    character(len=*), parameter :: group = "/test_group"
+    character(len=*), parameter :: key = "3d_integer_array"
+
+    integer(int64), allocatable :: array3d_read(:,:,:)
+    integer(int64), allocatable :: array3d(:,:,:)
+
+    logical :: arrays_equal
+
+    allocate(array3d(4,3,2))
+    do k = 1, 2
+      do j = 1, 3
+        do i = 1, 4
+           array3d(i,j,k) = i + 10*j + 100*k
+        end do
+      end do
+    end do
+
+    call hdf5_write_int(filename=filename, array_input_3d=array3d, key=key, group=group)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(array3d_read(dims(1), dims(2), dims(3)))
+
+    call h5dread_f(dset_id, H5T_STD_I64LE, array3d_read, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+    arrays_equal = all(array3d_read == array3d)
+
+    call check(error, .true. , arrays_equal)
+    if (allocated(error)) return
+  end subroutine test_hdf5_write_int_3d
+
+  subroutine test_hdf5_write_int_2d(error)
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+    integer :: j, k, error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(2) :: dims, maxdims
+    character(len=*), parameter :: filename = "test_output.h5"
+    character(len=*), parameter :: group = "/test_group"
+    character(len=*), parameter :: key = "2d_integer_array"
+
+    integer(int64), allocatable :: array2d_read(:,:)
+    integer(int64), allocatable :: array2d(:,:)
+
+    logical :: arrays_equal
+
+    allocate(array2d(3,2))
+    do k = 1, 2
+      do j = 1, 3
+           array2d(j,k) = 10*j + 100*k
+      end do
+    end do
+
+    call hdf5_write_int(filename=filename, array_input_2d=array2d, key=key, group=group)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(array2d_read(dims(1), dims(2)))
+
+    call h5dread_f(dset_id, H5T_STD_I64LE, array2d_read, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+    arrays_equal = all(array2d_read == array2d)
+
+    call check(error, .true. , arrays_equal)
+    if (allocated(error)) return
+  end subroutine test_hdf5_write_int_2d
+
+  subroutine test_hdf5_write_int_1d(error)
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+    integer :: k, error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(1) :: dims, maxdims
+    character(len=*), parameter :: filename = "test_output.h5"
+    character(len=*), parameter :: group = "/test_group"
+    character(len=*), parameter :: key = "1d_integer_array"
+
+    integer(int64), allocatable :: array1d_read(:)
+    integer(int64), allocatable :: array1d(:)
+
+    logical :: arrays_equal
+
+    allocate(array1d(2))
+    do k = 1, 2
+           array1d(k) = 100*k
+    end do
+
+    call hdf5_write_int(filename=filename, array_input_1d=array1d, key=key, group=group)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(array1d_read(dims(1)))
+
+    call h5dread_f(dset_id, H5T_STD_I64LE, array1d_read, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+    arrays_equal = all(array1d_read == array1d)
+
+    call check(error, .true. , arrays_equal)
+    if (allocated(error)) return
+  end subroutine test_hdf5_write_int_1d
+
+  subroutine test_hdf5_write_int_scalar(error)
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+    integer :: k, error_hdf5
+    integer(hid_t) :: file_id, group_id, attr_id, attr_space_id
+    INTEGER(HSIZE_T), DIMENSION(1) :: adims
+    character(len=*), parameter :: filename = "test_output.h5"
+    character(len=*), parameter :: group = "/test_group"
+    character(len=*), parameter :: key = "integer_scalar"
+
+    integer(int64) :: scalar_read
+    integer(int64) :: scalar
+
+    adims=1
+    scalar = 20
+
+    call hdf5_write_int(filename=filename, scalar_input=scalar, key=key, group=group)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5gopen_f(file_id, group, group_id, error_hdf5)
+
+    call h5aopen_name_f(group_id, key, attr_id, error_hdf5)
+
+
+    call h5aread_f(attr_id, H5T_STD_I64LE, scalar_read, adims, error_hdf5)
+
+    call h5aclose_f(attr_id, error_hdf5)
+    call h5gclose_f(group_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+    call check(error, scalar , scalar_read)
+    if (allocated(error)) return
+  end subroutine test_hdf5_write_int_scalar
+  
+end module test_hdf5_io
+#endif

--- a/test/test_hdf5_io.f90
+++ b/test/test_hdf5_io.f90
@@ -401,6 +401,6 @@ contains
     call check(error, scalar , scalar_read)
     if (allocated(error)) return
   end subroutine test_hdf5_write_int_scalar
-  
+
 end module test_hdf5_io
 #endif


### PR DESCRIPTION
This PR

Fixes https://github.com/BioFSILab/Bio-CFD/issues/237
Fixes a previously bug we were unaware of where an attempt to create a hdf5 file with the integer writing hdf5 subroutine would cause errors (see h5f_acc_rdwr_f change to h5f_acc_excl_f)
Fixes Fortitudes preview rules for the hdf5 module (previously this PR https://github.com/BioFSILab/Bio-CFD/pull/250). Changes included by accident, but didn't see them worth reverting and including in a separate PR once realised.
Adds some tests for the hdf5 module (checks the ability to write scalar, 1D/2D/3D arrays for both real and integer types).
