### PR TITLE
First commit of MPI helpers

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -35,9 +35,10 @@ PROGRAM main
         INTEGER (int64)   :: itamax, pcItaMax
         real(dp) :: aoa,aoa1,aoa2,phase_angle,piv_pt
         integer :: start, finish, step, rank
-        call biocfd_init(size(block), start, finish, step, rank)
 
         CALL readInput(surGeoPoints,char_f,istart,itamax,pcItaMax,aoa,phase_angle,piv_pt)
+        ! Need to init after we know the size of block
+        call biocfd_init(size(block), start, finish, step, rank)
         CALL readBlockInterface
         do g=1, size(block)
           if (g >= blk_start) CALL readSurfaceMeshGmsh(block(g),surGeoPoints)

--- a/app/main.F90
+++ b/app/main.F90
@@ -34,8 +34,8 @@ PROGRAM main
         INTEGER               :: istart
         INTEGER (int64)   :: itamax, pcItaMax
         real(dp) :: aoa,aoa1,aoa2,phase_angle,piv_pt
-        integer :: start, step, rank
-        call biocfd_init(size(block), start, step, rank)
+        integer :: start, finish, step, rank
+        call biocfd_init(size(block), start, finish, step, rank)
 
         CALL readInput(surGeoPoints,char_f,istart,itamax,pcItaMax,aoa,phase_angle,piv_pt)
         CALL readBlockInterface

--- a/app/main.F90
+++ b/app/main.F90
@@ -25,6 +25,7 @@ PROGRAM main
 #endif
         use biocfd_forcing, only: pressureForcing1, pressureforcingfield, pressureforcingghost, &
              velocityforcing1, velocityforcingfield, velocityforcingghost
+        use biocfd_mpi_helpers, only: biocfd_init, biocfd_finalize
         IMPLICIT NONE
 
         INTEGER (int64) :: g
@@ -33,6 +34,9 @@ PROGRAM main
         INTEGER               :: istart
         INTEGER (int64)   :: itamax, pcItaMax
         real(dp) :: aoa,aoa1,aoa2,phase_angle,piv_pt
+        integer :: start, step, rank
+        call biocfd_init(size(block), start, step, rank)
+
         CALL readInput(surGeoPoints,char_f,istart,itamax,pcItaMax,aoa,phase_angle,piv_pt)
         CALL readBlockInterface
         do g=1, size(block)
@@ -168,5 +172,6 @@ PROGRAM main
            CALL pressureForcingGhost(block(g))
         end do
         IF(ita>=itamax) EXIT
-        END DO
+     END DO
+     call biocfd_finalize()
       END PROGRAM main

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -12,12 +12,12 @@ module biocfd_mpi_helpers
 
   private
 
-  public :: biocfd_init, biocfd_finalize
+  public :: biocfd_init, biocfd_finalize, get_block_iteration_params
 
 contains
 
-  !> Initialize the steps that we will be performing over blocks. This
-  !> allows us to work out which blocks to put on each rank in the case of MPI.
+  !> Initialize MPI and then work out steps that we will be performing
+  !> over blocks with `get_block_iteration_params`.
   subroutine biocfd_init(nblocks, start, finish, step, rank)
     !> The total number of blocks we are simulating
     integer, intent(in) :: nblocks
@@ -30,17 +30,7 @@ contains
     integer :: required, provided
     ! An error value to check when using MPI
     integer :: ierror
-#endif
 
-
-#ifndef BIOCFD_MPI
-    ! If we aren't using MPI, it is straight forward. Our loop goes
-    ! over every block from 1 in steps of 1. Rank is set to 0.
-    start = 1
-    finish = nblocks
-    step = 1
-    rank = 0
-#else
     required = MPI_THREAD_SERIALIZED
     call MPI_Init_Thread(required, provided, ierror)
 
@@ -61,12 +51,8 @@ contains
        call MPI_Finalize()
        stop 1
     end if
-
-    ! MPI ranks are zero indexed, we want to start looping from 1 in
-    ! fortran
-    start = rank + 1
-    finish = nblocks
 #endif
+    call  get_block_iteration_params(nblocks, start, finish, step, rank)
   end subroutine biocfd_init
 
   !> Finalize is an no-op in the case that we aren't using MPI
@@ -76,5 +62,33 @@ contains
     call MPI_Finalize(ierror)
 #endif
   end subroutine biocfd_finalize
+
+!> Work out how work will be shared across MPI nodes
+subroutine get_block_iteration_params(nblocks, start, finish, step, rank)
+   !> The total number of blocks we are simulating
+    integer, intent(in) :: nblocks
+    !> The start, finish (both end and stop are keywords) and step size we will use to loop over blocks
+    integer, intent(out) :: start, finish, step
+    !> The MPI rank that we are running on (0 in the case we aren't using MPI)
+    integer, intent(out) :: rank
+#ifdef BIOCFD_MPI
+    ! An error value to check when using MPI
+    integer :: ierror
+    call MPI_Comm_size(MPI_COMM_WORLD, step, ierror)
+    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+    ! MPI ranks are zero indexed, we want to start looping from 1 in
+    ! fortran
+    start = rank + 1
+    finish = nblocks
+#else
+    ! If we aren't using MPI, it is straight forward. Our loop goes
+    ! over every block from 1 in steps of 1. Rank is set to 0.
+    start = 1
+    finish = nblocks
+    step = 1
+    rank = 0
+#endif
+
+end subroutine get_block_iteration_params
 
 end module biocfd_mpi_helpers

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -18,11 +18,11 @@ contains
 
   !> Initialize the steps that we will be performing over blocks. This
   !> allows us to work out which blocks to put on each rank in the case of MPI.
-  subroutine biocfd_init(nblocks, start, step, rank)
+  subroutine biocfd_init(nblocks, start, finish, step, rank)
     !> The total number of blocks we are simulating
     integer, intent(in) :: nblocks
-    !> The start and step size we will use to loop over blocks
-    integer, intent(out) :: start, step
+    !> The start, finish (both end and stop are keywords) and step size we will use to loop over blocks
+    integer, intent(out) :: start, finish, step
     !> The MPI rank that we are running on (0 in the case we aren't using MPI)
     integer, intent(out) :: rank
 #ifdef BIOCFD_MPI
@@ -37,6 +37,7 @@ contains
     ! If we aren't using MPI, it is straight forward. Our loop goes
     ! over every block from 1 in steps of 1. Rank is set to 0.
     start = 1
+    finish = nblocks
     step = 1
     rank = 0
 #else
@@ -64,6 +65,7 @@ contains
     ! MPI ranks are zero indexed, we want to start looping from 1 in
     ! fortran
     start = rank + 1
+    finish = nblocks
 #endif
   end subroutine biocfd_init
 

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -1,0 +1,78 @@
+!> This module is used for the initialisation and finalisation of MPI.
+!> It is written in such a way that the subroutines do the right thing
+!> regardless of whether the code is compiled with MPI support or not.
+module biocfd_mpi_helpers
+  use, intrinsic :: iso_fortran_env, only: error_unit
+#ifdef BIOCFD_MPI
+  use mpi_f08, only: MPI_Abort, MPI_Comm_rank, MPI_Comm_size, MPI_COMM_WORLD, MPI_Finalize, &
+                     MPI_Init_Thread, MPI_THREAD_SERIALIZED
+#endif
+
+  implicit none
+
+  private
+
+  public :: biocfd_init, biocfd_finalize
+
+contains
+
+  !> Initialize the steps that we will be performing over blocks. This
+  !> allows us to work out which blocks to put on each rank in the case of MPI.
+  subroutine biocfd_init(nblocks, start, step, rank)
+    !> The total number of blocks we are simulating
+    integer, intent(in) :: nblocks
+    !> The start and step size we will use to loop over blocks
+    integer, intent(out) :: start, step
+    !> The MPI rank that we are running on (0 in the case we aren't using MPI)
+    integer, intent(out) :: rank
+#ifdef BIOCFD_MPI
+    ! For MPI threading considerations
+    integer :: required, provided
+    ! An error value to check when using MPI
+    integer :: ierror
+#endif
+
+
+#ifndef BIOCFD_MPI
+    ! If we aren't using MPI, it is straight forward. Our loop goes
+    ! over every block from 1 in steps of 1. Rank is set to 0.
+    start = 1
+    step = 1
+    rank = 0
+#else
+    required = MPI_THREAD_SERIALIZED
+    call MPI_Init_Thread(required, provided, ierror)
+
+    if (provided < required) then
+       write(error_unit, *) "MPI does not provide the required threading support. Aborting!"
+       call MPI_Abort(MPI_COMM_WORLD, 1, ierror)
+    end if
+
+    call MPI_Comm_size(MPI_COMM_WORLD, step, ierror)
+    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+
+    if (step > nblocks) then
+       if (rank == 0) then
+          write(error_unit, *) "You have launched the program with more processes than blocks."
+          write(error_unit, *) "This will lead to wasted resources."
+          write(error_unit, *) "Please resubmit the job with the number of processors <= ", nblocks
+       end if
+       call MPI_Finalize()
+       stop 1
+    end if
+
+    ! MPI ranks are zero indexed, we want to start looping from 1 in
+    ! fortran
+    start = rank + 1
+#endif
+  end subroutine biocfd_init
+
+  !> Finalize is an no-op in the case that we aren't using MPI
+  subroutine biocfd_finalize()
+#ifdef BIOCFD_MPI
+    integer :: ierror
+    call MPI_Finalize(ierror)
+#endif
+  end subroutine biocfd_finalize
+
+end module biocfd_mpi_helpers


### PR DESCRIPTION
This adds a new module `biocfd_mpi_helpers` that will setup the strategy for splitting blocks across nodes. Currently, the strategy is taken from the MPI R&D branch (https://github.com/BioFSILab/Bio-CFD/blob/4d2640beabd0b865597af662eccd512c9fd6862c/app/main.F90#L54-L75) which is a pretty naive way of doing it as each node handles the same number of blocks, which won't be a good choice in the case you have 4 GPUs on node *A* and 1 GPU on node *B*.

I **think** that this is still a good starting point, and even if we change the algorithm the structure works the same. The idea is that `biocfd_init` gives us the loop arguments(?) that we'll use in main.

As a concrete example with the current implementation for two ranks, and ten blocks we'll get
```
Rank 0: start = 1, finish = 10, step=2
Rank 1: start = 2, finish = 10, step=2
```
The loop would be something like
```f90
do g=start, finish, step
  print *, g
end do
```
So rank 0: would print `1, 3, 5, 7, 9` and rank 1 would print `2, 4, 6, 8, 10` 