### PR TITLE
[wip] Add logfile module for debugging

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -26,6 +26,7 @@
 #endif
         use biocfd_forcing, only: pressureForcing1, pressureforcingfield, pressureforcingghost, &
              velocityforcing1, velocityforcingfield, velocityforcingghost
+        use biocfd_debug_log, only: log_file_open, log_file_close, log_file_write
         IMPLICIT NONE
 
         INTEGER (int64) :: g
@@ -34,6 +35,8 @@
         INTEGER               :: istart
         INTEGER (int64)   :: itamax, pcItaMax
         real(dp) :: aoa,aoa1,aoa2,phase_angle,piv_pt
+        call log_file_open()
+        call log_file_write("main","Start of log file")
         CALL readInput(surGeoPoints,char_f,istart,itamax,pcItaMax,aoa,phase_angle,piv_pt)
         CALL readBlockInterface
         do g=blk_start, size(block)
@@ -225,6 +228,8 @@
         end do
         IF(ita>=itamax) EXIT
         END DO
+      call log_file_write("main","end of log file")
+      call log_file_close()
       END PROGRAM main
 
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -10,7 +10,7 @@ auto-examples = true
 external-modules = ["hdf5", "openacc", "mpi_f08"]
 
 [preprocess]
-cpp.macros = ["USE_HDF5=0"]
+cpp.macros = ["USE_HDF5=0","CREATE_LOGFILE=0"]
 
 
 [install]

--- a/src/debug_log.F90
+++ b/src/debug_log.F90
@@ -1,0 +1,31 @@
+module biocfd_debug_log
+       implicit none
+       private
+
+       integer :: log_file_unit
+
+#if CREATE_LOGFILE == 1
+       logical, parameter :: write_to_logfile=.true.
+#else
+       logical, parameter :: write_to_logfile=.false.
+#endif
+       
+       public :: log_file_open, log_file_close, log_file_write
+       
+       contains
+
+         subroutine log_file_open()
+           if(write_to_logfile) open(newunit=log_file_unit, file="log_file.txt")
+         end subroutine log_file_open
+
+         subroutine log_file_write(subroutine_name, log_message)
+           character(len=*), intent(in) :: subroutine_name, log_message
+           if(write_to_logfile) write(log_file_unit,*) subroutine_name," ",log_message           
+         end subroutine log_file_write
+
+         subroutine log_file_close()
+           if(write_to_logfile) close(log_file_unit)
+         end subroutine log_file_close
+
+end module biocfd_debug_log
+


### PR DESCRIPTION
This module could be used to replace the many debug write statements in the code with calls to `log_file_write` which will write nothing by default unless CREATE_LOGFILE is to 1.