### PR TITLE
Add block allocation checks to Search for MPI

### DIFF
--- a/src/Search.F90
+++ b/src/Search.F90
@@ -1029,6 +1029,12 @@ blk%fluidCellCount = flcnt
         DO g=1,size(intfr)
         a_blk_no=intfr(g)%a_blk
         b_blk_no=intfr(g)%b_blk
+
+        ! Here we check if array is allocated. This is important for
+        ! MPI, as the arrays may not be allocated on this rank. When
+        ! not running in MPI mode, this should always be allocated.
+        if (.not. allocated(block(b_blk_no)%u)) cycle
+
         mg1=block(b_blk_no)%cintp*block(1)%dx
         marginx=4.5_dp*mg1
         marginy=5*mg1
@@ -1294,6 +1300,11 @@ blk%fluidCellCount = flcnt
         type(Block_t), intent(inout) :: blk
         INTEGER(int64) :: k,j,i,countx_st,countz_st,county_st
 
+        ! Here we check if array is allocated. This is important for
+        ! MPI, as the arrays may not be allocated on this rank. When
+        ! not running in MPI mode, this should always be allocated.
+         if (.not. allocated(blk%u)) return
+
         if ( blk% move_check /= 1) return
         blk%cell_n=0
         DO k=1,blk%nz+2
@@ -1392,6 +1403,11 @@ SUBROUTINE change_block_interface(local_intfr,blk_a,blk_b)
   type(Interface_t),intent(inout) :: local_intfr
   type(Block_t), intent(in) :: blk_a, blk_b
   INTEGER(int64) :: factor, increment
+
+  ! Here we check if array is allocated. This is important for
+  ! MPI, as the arrays may not be allocated on this rank. When
+  ! not running in MPI mode, this should always be allocated.
+  if (.not. allocated(blk_b%u)) return
 
   if ( blk_b%move_check /= 1) return
   factor=local_intfr%b_msh/local_intfr%a_msh


### PR DESCRIPTION
Adds `allocated` checks to `Search` for MPI. These will work even if not compiled in MPI mode because arrays are allocated for every block in that case.