### PR TITLE
More parallel in main

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -26,6 +26,7 @@ PROGRAM main
         use biocfd_forcing, only: pressureForcing1, pressureforcingfield, pressureforcingghost, &
              velocityforcing1, velocityforcingfield, velocityforcingghost
         use biocfd_mpi_helpers, only: biocfd_init, biocfd_finalize
+        use biocfd_gpu_helpers, only: set_gpu
 #ifdef BIOCFD_MPI
         use mpi_f08, only: MPI_Allreduce, MPI_Bcast, MPI_COMM_WORLD, MPI_DOUBLE_PRECISION, &
                            MPI_IN_PLACE, MPI_INTEGER8, MPI_Max
@@ -72,12 +73,18 @@ PROGRAM main
         totime = 0.
         ita1 = 0
 
+        !$omp parallel default(none) private(g) shared(block, start, finish, step)
+        ! Set the device (for multi-GPU)
+        call set_gpu()
+        !$omp do
         do g=start, finish, step
           if (g /= 1) then
            CALL tagging_th(block(g), g)
            CALL cellCount_solid(block(g), g)
           end if
         end do
+        !$omp end do
+        !$omp end parallel
 
         ! Just run fine_block_cell on rank 1 (note that we'll need to
         ! be sure that only block(1) is being written to)
@@ -217,6 +224,10 @@ PROGRAM main
             if (g /= 1) CALL tagging_th_move(block(g), g)
          end do
 
+        !$omp parallel default(none) private(g) shared(block, start, finish, step)
+        ! Set the device (for multi-GPU)
+        call set_gpu()
+        !$omp do
         DO g=start, finish, step
           if (g == 1) cycle
           CALL selectiveRetagging_th(block(g))
@@ -243,6 +254,8 @@ PROGRAM main
           CALL velocityForcingGhost(block(g))
           CALL pressureForcingGhost(block(g))
         end do
+        !$omp end do
+        !$omp end parallel
         IF(ita>=itamax) EXIT
      END DO
      call biocfd_finalize()

--- a/app/main.F90
+++ b/app/main.F90
@@ -139,7 +139,6 @@ PROGRAM main
            if (g == 1) CALL velocityBC(block(g), deltat, uc)
            if (g /= 1) then
              CALL solidCellBC(block(g))
-           !$acc wait
              CALL velocityForcing1(block(g))
            end if
            ! TODO: Not sure why velocityBC is called twice in a row for block(1)?

--- a/app/main.F90
+++ b/app/main.F90
@@ -129,6 +129,11 @@ PROGRAM main
         DO
         ita = ita + 1
         totime = totime + deltat
+
+        !$omp parallel default(none) private(g) shared(block, start, finish, step, deltat, uc)
+        ! Set the device (for multi-GPU)
+        call set_gpu()
+        !$omp do
         do g=start, finish, step
            CALL nsMomentum2order(block(g))
            if (g == 1) CALL velocityBC(block(g), deltat, uc)
@@ -140,6 +145,8 @@ PROGRAM main
            ! TODO: Not sure why velocityBC is called twice in a row for block(1)?
            if (g == 1) CALL velocityBC(block(g), deltat, uc)
         end do
+        !$omp end do
+        !$omp end parallel
 
         CALL poissonSolver(pcItaMax)
 


### PR DESCRIPTION
Making this so I don't forget where I'm up to. Relies on #265 being merged first.

Note: There is an OpenMP region in `tagging_th` if OpenACC isn't used, which creates nested OMP parallel regions. By default (at least on my laptop), the inner OpenMP directives will just be ignored, unless nested OMP is explicitly enabled. This can be done with environment variables e.g.

`OMP_MAX_ACTIVE_LEVELS=2 OMP_NUM_THREADS=2,4`

will allow 2 levels, with the first level using 2 threads and the inner level using 4 threads. 

I *think* that a single value `OMP_NUM_THREADS` doesn't really work here because each level will use that many threads (so if we set `OMP_MAX_ACTIVE_LEVELS=2 OMP_NUM_THREADS=8` then we'll get 8 threads on level one and each of those 8 threads will spawn 8 threads. I'm not 100% sure of this however.