### PR TITLE
Don't overwrite body plot for multiple butterflies

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -163,7 +163,7 @@ PROGRAM main
 #ifndef BIOCFD_MPI
            ! TODO: Not yet tested on MPI but should be added!
            CALL writeResult(block(g),g,char_f)
-           CALL body_plot(block(g))
+           CALL body_plot(block(g), g)
 #endif
        end do
 

--- a/src/WriteOutput_corner1.F90
+++ b/src/WriteOutput_corner1.F90
@@ -135,14 +135,14 @@ contains
 
       END SUBROUTINE writeResult
 
-         SUBROUTINE body_plot(blk)
+         SUBROUTINE body_plot(blk, blk_id)
          type(Block_t), intent(in) :: blk
+         integer(int64), intent(in) :: blk_id
          INTEGER(int64) :: inode, ielem
          CHARACTER(len=150) :: filename1
 
           if (ita /= 1) return
-          WRITE(filename1,108)
-  108     FORMAT("out/butterfly.dat")
+          WRITE(filename1, "('out/butterfly_', i3.3, '.dat')") blk_id
           OPEN(UNIT=857,FILE=filename1,STATUS="unknown")
           WRITE(857,*) 'TITLE = "FEstressplot"'
           WRITE(857,*) 'VARIABLES= "x", "y", "z","bd_n"'


### PR DESCRIPTION
Closes #240. Writes individual files per butterfly when body_plot is called.