### PR TITLE
Mpi helpers gpu aware

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -148,7 +148,7 @@ PROGRAM main
         !$omp end do
         !$omp end parallel
 
-        CALL poissonSolver(pcItaMax)
+        CALL poissonSolver(pcItaMax, start, finish, step)
 
         do g=start, finish, step
            if (g /= 1) CALL pressureForcing1(block(g))

--- a/src/PcorVcor.F90
+++ b/src/PcorVcor.F90
@@ -10,7 +10,6 @@ module biocfd_pcor_vcor
   use biocfd_fine_interp_bound, only : fineUpdate_newv_bd, fineUpdate_pc_bd, fineupdate_bd_mv
   use biocfd_coarse_update, only : coarseUpdate_newv, coarseUpdate_pc, coarseUpdate
   use biocfd_boundary_conditions, only : velocityBC
-  use biocfd_mpi_helpers, only: get_block_iteration_params
 #ifdef BIOCFD_MPI
    use mpi_f08, only: MPI_Bcast, MPI_COMM_WORLD, MPI_DOUBLE_PRECISION
 #endif
@@ -49,8 +48,6 @@ module biocfd_pcor_vcor
 
           ! Dummy values for omp/acc variables
           omp_threads = 1
-
-          call get_block_iteration_params(size(block), start, finish, step, rank)
 
 #ifdef _OPENMP
           ! Count the number of blocks on this rank (or in total if not

--- a/src/PcorVcor.F90
+++ b/src/PcorVcor.F90
@@ -21,7 +21,7 @@ module biocfd_pcor_vcor
 
   contains
 
-      SUBROUTINE poissonSolver(pcItaMax)
+      SUBROUTINE poissonSolver(pcItaMax, start, finish, step)
 
         INTEGER(int64) :: i, j,k, n, g
         INTEGER (int64),INTENT(IN)   :: pcItaMax
@@ -31,11 +31,11 @@ module biocfd_pcor_vcor
 #ifndef BIOCFD_MPI
         CHARACTER(len=160) :: filename1
 #endif
+        !> Variables to control iteration over blocks (mainly for MPI)
+        integer, intent(in) :: start, finish, step
 
         ! For controlling OpenMP
         integer :: omp_threads
-        ! Variables to control iteration over blocks (mainly for MPI)
-        integer :: start, finish, step, rank
 
           max_derrStdst=0._dp
           max_derr1=0._dp

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -8,7 +8,7 @@ module biocfd_mpi_helpers
                      MPI_Finalize, MPI_Init_Thread, MPI_IN_PLACE, MPI_INTEGER, MPI_THREAD_SERIALIZED
 #endif
 #ifdef _OPENACC
-  use openacc, only: acc_device_default, acc_device_host, acc_get_num_devices, acc_set_device_type
+  use openacc, only: acc_device_default, acc_get_num_devices
 #endif
 
   implicit none
@@ -139,17 +139,10 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
 
     rank_gpus(rank + 1) = acc_get_num_devices(acc_device_default)
 
-    ! The device type is set to the host due a crash that has been
-    ! seen in the AllGather operation. It seems that CUDA-aware MPI
-    ! can start doing things on the GPU that we don't really want it
-    ! to. Setting the device type to host here (and then back to the
-    ! GPU once the AllGather is complete) seems to not crash.
-    call acc_set_device_type(acc_device_host)
     ! Gather all GPUs together such that every rank has an array of
     ! GPU numbers
     call MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, rank_gpus, 1, MPI_INTEGER, &
                        MPI_COMM_WORLD, ierror)
-    call acc_set_device_type(acc_device_default)
     total_gpus = sum(rank_gpus)
 
     ! This is how many blocks we need to have per GPU

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -133,6 +133,9 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     allocate(rank_gpus(world_size))
     ! This is the number of blocks we are going to place on each rank
     allocate(rank_blocks(world_size))
+    ! This is the "ideal" number of GPUs on each rank i.e. if we could
+    ! split blocks fractionally
+    allocate(ideal_blocks(world_size))
 
     rank_gpus(rank + 1) = acc_get_num_devices(acc_device_default)
 

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -141,7 +141,7 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     rank_blocks = nint(rank_gpus * real_blocks_per_gpu)
 
     start = sum(rank_blocks(1:rank))
-    finsh = sum(rank_blocks(1:rank+1))
+    finish = sum(rank_blocks(1:rank+1))
     step = 1
     print *, "Testing - start = ", start, "finish = ", finish
 #else

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -147,6 +147,8 @@ subroutine get_block_iteration_params(nblocks, start, finish, step, rank)
     start = sum(rank_blocks(1:rank)) + 1
     finish = sum(rank_blocks(1:rank+1))
     step = 1
+    print *, "MPI config - rank = ", rank, "gpus = ", this_rank_gpus, &
+             "start = ", start, "finish = ", finish
 #elif defined(BIOCFD_MPI)
     ! An error value to check when using MPI
     integer :: ierror

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -7,6 +7,9 @@ module biocfd_mpi_helpers
   use mpi_f08, only: MPI_Abort, MPI_Comm_rank, MPI_Comm_size, MPI_COMM_WORLD, MPI_Finalize, &
                      MPI_Init_Thread, MPI_THREAD_SERIALIZED
 #endif
+#ifdef _OPENACC
+  use openacc, only: acc_device_default, acc_get_num_devices
+#endif
 
   implicit none
 
@@ -90,5 +93,66 @@ subroutine get_block_iteration_params(nblocks, start, finish, step, rank)
 #endif
 
 end subroutine get_block_iteration_params
+
+!> Work out how work will be shared across MPI nodes when we have
+!> multiple GPUs! The idea here is that we will work out how many GPUs
+!> our rank has and how many GPUs there are overall. We can then split
+!> the blocks proportionally across nodes. Each rank must have at
+!> least one GPU for this to work.
+subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
+   !> The total number of blocks we are simulating
+    integer, intent(in) :: nblocks
+    !> The start, finish (both end and stop are keywords) and step size we will use to loop over blocks
+    integer, intent(out) :: start, finish, step
+    !> The MPI rank that we are running on (0 in the case we aren't using MPI)
+    integer, intent(out) :: rank
+#if defined(BIOCFD_MPI) && defined(_OPENACC)
+    ! An error value to check when using MPI
+    integer :: ierror
+
+    integer :: world_size
+    integer, allocatable :: rank_gpus(:), rank_blocks(:)
+    integer :: total_gpus
+    !> This is blocks per GPU computed as nblocks / total_gpus (real
+    !> as in a floating point number)
+    real :: real_blocks_per_gpu
+    ! Looping variable
+    integer:: i
+
+    call MPI_Comm_size(MPI_COMM_WORLD, world_size, ierror)
+    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+
+    ! Get an array of GPUs and fill accordingly
+    allocate(rank_gpus(world_size))
+    rank_gpus(rank + 1) = acc_get_num_devices(acc_device_default)
+
+    ! Gather all GPUs together such that every rank has an array of
+    ! GPU numbers
+    call MPI_Allgather(MPI_IN_PLACE, 0, MPI_INTEGER, rank_gpus, 1, MPI_INTEGER, MPI_COMM_WORLD, & 
+                       ierror)
+    total_gpus = sum(rank_gpus)
+
+    ! This is how many blocks we need to have per GPU
+    real_blocks_per_gpu = real(nblocks) / total_gpus
+
+    ! This is the number of blocks we are going to place on each rank
+    allocate(rank_blocks(world_size))
+    ! This is the rounded number of blocks on each rank
+    rank_blocks = nint(rank_gpus * real_blocks_per_gpu)
+
+    start = sum(rank_blocks(1:rank))
+    finsh = sum(rank_blocks(1:rank+1))
+    step = 1
+    print *, "Testing - start = ", start, "finish = ", finish
+#else
+    ! If we aren't using MPI, it is straight forward. Our loop goes
+    ! over every block from 1 in steps of 1. Rank is set to 0.
+    start = 1
+    finish = nblocks
+    step = 1
+    rank = 0
+#endif
+
+end subroutine get_block_iteration_params_gpu
 
 end module biocfd_mpi_helpers

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -15,7 +15,7 @@ module biocfd_mpi_helpers
 
   private
 
-  public :: biocfd_init, biocfd_finalize, get_block_iteration_params
+  public :: biocfd_init, biocfd_finalize
 
 contains
 
@@ -55,7 +55,7 @@ contains
        stop 1
     end if
 #endif
-    call  get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
+    call  get_block_iteration_params(nblocks, start, finish, step, rank)
   end subroutine biocfd_init
 
   !> Finalize is an no-op in the case that we aren't using MPI
@@ -66,45 +66,18 @@ contains
 #endif
   end subroutine biocfd_finalize
 
-!> Work out how work will be shared across MPI nodes
-subroutine get_block_iteration_params(nblocks, start, finish, step, rank)
-   !> The total number of blocks we are simulating
-    integer, intent(in) :: nblocks
-    !> The start, finish (both end and stop are keywords) and step size we will use to loop over blocks
-    integer, intent(out) :: start, finish, step
-    !> The MPI rank that we are running on (0 in the case we aren't using MPI)
-    integer, intent(out) :: rank
-#ifdef BIOCFD_MPI
-    ! An error value to check when using MPI
-    integer :: ierror
-    call MPI_Comm_size(MPI_COMM_WORLD, step, ierror)
-    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
-    ! MPI ranks are zero indexed, we want to start looping from 1 in
-    ! fortran
-    start = rank + 1
-    finish = nblocks
-#else
-    ! If we aren't using MPI, it is straight forward. Our loop goes
-    ! over every block from 1 in steps of 1. Rank is set to 0.
-    start = 1
-    finish = nblocks
-    step = 1
-    rank = 0
-#endif
-
-end subroutine get_block_iteration_params
-
-!> Work out how work will be shared across MPI nodes when we have
-!> multiple GPUs! The idea here is that we will work out how many GPUs
-!> our rank has and how many GPUs there are overall. We can then split
-!> the blocks proportionally across nodes. Each rank must have at
-!> least one GPU for this to work. The algorithm used is a [Quota
-!> Method](https://en.wikipedia.org/wiki/Quota_method), more
+!> Work out how work will be shared across MPI nodes.
+!>
+!> In the case of multiple the idea here is that we will work out how
+!> many GPUs our rank has and how many GPUs there are overall. We can
+!> then split the blocks proportionally across nodes. Each rank must
+!> have at least one GPU for this to work. The algorithm used is a
+!> [Quota Method](https://en.wikipedia.org/wiki/Quota_method), more
 !> specifially a largest-remainder method, using the Hare Quota. While
 !> this method certainly has its drawbacks when electing
 !> representatives it should be suitable for dividing blocks amongst
 !> GPUs!
-subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
+subroutine get_block_iteration_params(nblocks, start, finish, step, rank)
    !> The total number of blocks we are simulating
     integer, intent(in) :: nblocks
     !> The start, finish (both end and stop are keywords) and step size we will use to loop over blocks
@@ -118,11 +91,11 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     integer :: world_size
     integer, allocatable :: rank_gpus(:), rank_blocks(:)
     integer :: this_rank_gpus, total_gpus
-    !> This is blocks per GPU computed as nblocks / total_gpus (real
-    !> as in a floating point number)
+    ! This is blocks per GPU computed as nblocks / total_gpus (real as
+    ! in a floating point number)
     real(real32) :: real_blocks_per_gpu
-    !> This is the ideal number of blocks we should have on each node
-    !> from straight division
+    ! This is the ideal number of blocks we should have on each node
+    ! from straight division
     real(real32), allocatable :: ideal_blocks(:)
     integer :: remaining_blocks, i, j
 
@@ -171,13 +144,18 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
       rank_blocks(j) = rank_blocks(j) + 1
     end do
 
-    ! TODO: More testing is needed
     start = sum(rank_blocks(1:rank)) + 1
     finish = sum(rank_blocks(1:rank+1))
-
     step = 1
-    print *, "MPI config - rank = ", rank, "gpus = ", rank_gpus, &
-             "start = ", start, "finish = ", finish
+#elif defined(BIOCFD_MPI)
+    ! An error value to check when using MPI
+    integer :: ierror
+    call MPI_Comm_size(MPI_COMM_WORLD, step, ierror)
+    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+    ! MPI ranks are zero indexed, we want to start looping from 1 in
+    ! fortran
+    start = rank + 1
+    finish = nblocks
 #else
     ! If we aren't using MPI, it is straight forward. Our loop goes
     ! over every block from 1 in steps of 1. Rank is set to 0.
@@ -187,6 +165,5 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     rank = 0
 #endif
 
-end subroutine get_block_iteration_params_gpu
-
+end subroutine get_block_iteration_params
 end module biocfd_mpi_helpers

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -140,7 +140,7 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     ! This is the rounded number of blocks on each rank
     rank_blocks = nint(rank_gpus * real_blocks_per_gpu)
 
-    start = sum(rank_blocks(1:rank))
+    start = sum(rank_blocks(1:rank)) + 1
     finish = sum(rank_blocks(1:rank+1))
     step = 1
     print *, "Testing - start = ", start, "finish = ", finish

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -140,10 +140,12 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     ! This is the rounded number of blocks on each rank
     rank_blocks = nint(rank_gpus * real_blocks_per_gpu)
 
+    ! 
     start = sum(rank_blocks(1:rank)) + 1
     finish = sum(rank_blocks(1:rank+1))
     step = 1
-    print *, "Testing - start = ", start, "finish = ", finish
+    print *, "MPI config - rank = ", rank, "gpus = ", rank_gpus, & 
+             "start = ", start, "finish = ", finish
 #else
     ! If we aren't using MPI, it is straight forward. Our loop goes
     ! over every block from 1 in steps of 1. Rank is set to 0.

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -4,8 +4,8 @@
 module biocfd_mpi_helpers
   use, intrinsic :: iso_fortran_env, only: error_unit, real32
 #ifdef BIOCFD_MPI
-  use mpi_f08, only: MPI_Abort, MPI_Comm_rank, MPI_Comm_size, MPI_COMM_WORLD, MPI_Finalize, &
-                     MPI_Init_Thread, MPI_IN_PLACE, MPI_INTEGER, MPI_THREAD_SERIALIZED
+  use mpi_f08, only: MPI_Abort, MPI_Comm_rank, MPI_Comm_size, MPI_COMM_WORLD, MPI_DATATYPE_NULL, &
+                     MPI_Finalize, MPI_Init_Thread, MPI_IN_PLACE, MPI_INTEGER, MPI_THREAD_SERIALIZED
 #endif
 #ifdef _OPENACC
   use openacc, only: acc_device_default, acc_get_num_devices
@@ -122,12 +122,13 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
 
     ! Get an array of GPUs and fill accordingly
     allocate(rank_gpus(world_size))
+    rank_gpus = 0
     rank_gpus(rank + 1) = acc_get_num_devices(acc_device_default)
 
     ! Gather all GPUs together such that every rank has an array of
     ! GPU numbers
-    call MPI_Allgather(MPI_IN_PLACE, 0, MPI_INTEGER, rank_gpus, 1, MPI_INTEGER, MPI_COMM_WORLD, &
-                       ierror)
+    call MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, rank_gpus, 1, MPI_INTEGER, &
+                       MPI_COMM_WORLD, ierror)
     total_gpus = sum(rank_gpus)
 
     ! This is how many blocks we need to have per GPU

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -4,8 +4,8 @@
 module biocfd_mpi_helpers
   use, intrinsic :: iso_fortran_env, only: error_unit, real32
 #ifdef BIOCFD_MPI
-  use mpi_f08, only: MPI_Abort, MPI_Comm_rank, MPI_Comm_size, MPI_COMM_WORLD, MPI_DATATYPE_NULL, &
-                     MPI_Finalize, MPI_Init_Thread, MPI_IN_PLACE, MPI_INTEGER, MPI_THREAD_SERIALIZED
+  use mpi_f08, only: MPI_Abort, MPI_Bcast, MPI_Comm_rank, MPI_Comm_size, MPI_COMM_WORLD, &
+                     MPI_Finalize, MPI_Gather, MPI_Init_Thread, MPI_INTEGER, MPI_THREAD_SERIALIZED
 #endif
 #ifdef _OPENACC
   use openacc, only: acc_device_default, acc_get_num_devices

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -2,7 +2,7 @@
 !> It is written in such a way that the subroutines do the right thing
 !> regardless of whether the code is compiled with MPI support or not.
 module biocfd_mpi_helpers
-  use, intrinsic :: iso_fortran_env, only: error_unit
+  use, intrinsic :: iso_fortran_env, only: error_unit, real32
 #ifdef BIOCFD_MPI
   use mpi_f08, only: MPI_Abort, MPI_Comm_rank, MPI_Comm_size, MPI_COMM_WORLD, MPI_Finalize, &
                      MPI_Init_Thread, MPI_IN_PLACE, MPI_INTEGER, MPI_THREAD_SERIALIZED
@@ -115,7 +115,7 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     integer :: total_gpus
     !> This is blocks per GPU computed as nblocks / total_gpus (real
     !> as in a floating point number)
-    real :: real_blocks_per_gpu
+    real(real32) :: real_blocks_per_gpu
     ! Looping variable
     integer:: i
 
@@ -128,7 +128,7 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
 
     ! Gather all GPUs together such that every rank has an array of
     ! GPU numbers
-    call MPI_Allgather(MPI_IN_PLACE, 0, MPI_INTEGER, rank_gpus, 1, MPI_INTEGER, MPI_COMM_WORLD, & 
+    call MPI_Allgather(MPI_IN_PLACE, 0, MPI_INTEGER, rank_gpus, 1, MPI_INTEGER, MPI_COMM_WORLD, &
                        ierror)
     total_gpus = sum(rank_gpus)
 
@@ -140,11 +140,18 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     ! This is the rounded number of blocks on each rank
     rank_blocks = nint(rank_gpus * real_blocks_per_gpu)
 
-    ! 
+    ! TODO: More testing is needed
     start = sum(rank_blocks(1:rank)) + 1
     finish = sum(rank_blocks(1:rank+1))
+
+    ! Due to the nint, it may be that we end up with sum(rank_blocks)
+    ! greater than nblocks. In this case, we'll just cap the finish
+    ! value to nblocks. Need to think if there is a better way to deal
+    ! with this.
+    finish = min(finish, nblocks)
+
     step = 1
-    print *, "MPI config - rank = ", rank, "gpus = ", rank_gpus, & 
+    print *, "MPI config - rank = ", rank, "gpus = ", rank_gpus, &
              "start = ", start, "finish = ", finish
 #else
     ! If we aren't using MPI, it is straight forward. Our loop goes

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -5,7 +5,7 @@ module biocfd_mpi_helpers
   use, intrinsic :: iso_fortran_env, only: error_unit
 #ifdef BIOCFD_MPI
   use mpi_f08, only: MPI_Abort, MPI_Comm_rank, MPI_Comm_size, MPI_COMM_WORLD, MPI_Finalize, &
-                     MPI_Init_Thread, MPI_THREAD_SERIALIZED
+                     MPI_Init_Thread, MPI_IN_PLACE, MPI_INTEGER, MPI_THREAD_SERIALIZED
 #endif
 #ifdef _OPENACC
   use openacc, only: acc_device_default, acc_get_num_devices

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -67,7 +67,7 @@ contains
   end subroutine biocfd_finalize
 
   !> Work out how work will be shared across MPI nodes.
-  !> 
+  !>
   !> In the case of multiple GPUs the idea here is that we will work out how
   !> many GPUs our rank has and how many GPUs there are overall. We can
   !> then split the blocks proportionally across nodes. Each rank must

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -98,7 +98,12 @@ end subroutine get_block_iteration_params
 !> multiple GPUs! The idea here is that we will work out how many GPUs
 !> our rank has and how many GPUs there are overall. We can then split
 !> the blocks proportionally across nodes. Each rank must have at
-!> least one GPU for this to work.
+!> least one GPU for this to work. The algorithm used is a [Quota
+!> Method](https://en.wikipedia.org/wiki/Quota_method), more
+!> specifially a largest-remainder method, using the Hare Quota. While
+!> this method certainly has its drawbacks when electing
+!> representatives it should be suitable for dividing blocks amongst
+!> GPUs!
 subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
    !> The total number of blocks we are simulating
     integer, intent(in) :: nblocks
@@ -116,13 +121,19 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     !> This is blocks per GPU computed as nblocks / total_gpus (real
     !> as in a floating point number)
     real(real32) :: real_blocks_per_gpu
+    !> This is the ideal number of blocks we should have on each node
+    !> from straight division
+    real(real32), allocatable :: ideal_blocks(:)
+    integer :: remaining_blocks, i, j
 
     call MPI_Comm_size(MPI_COMM_WORLD, world_size, ierror)
     call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
 
     ! Get an array of GPUs and fill accordingly
     allocate(rank_gpus(world_size))
-    rank_gpus = 0
+    ! This is the number of blocks we are going to place on each rank
+    allocate(rank_blocks(world_size))
+
     rank_gpus(rank + 1) = acc_get_num_devices(acc_device_default)
 
     ! Gather all GPUs together such that every rank has an array of
@@ -134,20 +145,26 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     ! This is how many blocks we need to have per GPU
     real_blocks_per_gpu = real(nblocks) / total_gpus
 
-    ! This is the number of blocks we are going to place on each rank
-    allocate(rank_blocks(world_size))
-    ! This is the rounded number of blocks on each rank
-    rank_blocks = nint(rank_gpus * real_blocks_per_gpu)
+    ! This is the "ideal" number of GPUs on each rank i.e. if we could
+    ! split blocks fractionally
+    ideal_blocks = rank_gpus * real_blocks_per_gpu
+
+    ! int does floor division
+    rank_blocks = int(ideal_blocks)
+
+    ! How many blocks have not been allocated
+    remaining_blocks = nblocks - sum(rank_blocks)
+
+    do i=1, remaining_blocks
+      ! Work out the rank with the maximum remainder, that gets given
+      ! the next block
+      j = maxloc(ideal_blocks - rank_blocks, dim=1)
+      rank_blocks(j) = rank_blocks(j) + 1
+    end do
 
     ! TODO: More testing is needed
     start = sum(rank_blocks(1:rank)) + 1
     finish = sum(rank_blocks(1:rank+1))
-
-    ! Due to the nint, it may be that we end up with sum(rank_blocks)
-    ! greater than nblocks. In this case, we'll just cap the finish
-    ! value to nblocks. Need to think if there is a better way to deal
-    ! with this.
-    finish = min(finish, nblocks)
 
     step = 1
     print *, "MPI config - rank = ", rank, "gpus = ", rank_gpus, &

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -66,19 +66,19 @@ contains
 #endif
   end subroutine biocfd_finalize
 
-!> Work out how work will be shared across MPI nodes.
-!>
-!> In the case of multiple the idea here is that we will work out how
-!> many GPUs our rank has and how many GPUs there are overall. We can
-!> then split the blocks proportionally across nodes. Each rank must
-!> have at least one GPU for this to work. The algorithm used is a
-!> [Quota Method](https://en.wikipedia.org/wiki/Quota_method), more
-!> specifially a largest-remainder method, using the Hare Quota. While
-!> this method certainly has its drawbacks when electing
-!> representatives it should be suitable for dividing blocks amongst
-!> GPUs!
-subroutine get_block_iteration_params(nblocks, start, finish, step, rank)
-   !> The total number of blocks we are simulating
+  !> Work out how work will be shared across MPI nodes.
+  !> 
+  !> In the case of multiple GPUs the idea here is that we will work out how
+  !> many GPUs our rank has and how many GPUs there are overall. We can
+  !> then split the blocks proportionally across nodes. Each rank must
+  !> have at least one GPU for this to work. The algorithm used is a
+  !> [Quota Method](https://en.wikipedia.org/wiki/Quota_method), more
+  !> specifially a largest-remainder method, using the Hare Quota. While
+  !> this method certainly has its drawbacks when electing
+  !> representatives it should be suitable for dividing blocks amongst
+  !> GPUs!
+  subroutine get_block_iteration_params(nblocks, start, finish, step, rank)
+    !> The total number of blocks we are simulating
     integer, intent(in) :: nblocks
     !> The start, finish (both end and stop are keywords) and step size we will use to loop over blocks
     integer, intent(out) :: start, finish, step
@@ -167,5 +167,6 @@ subroutine get_block_iteration_params(nblocks, start, finish, step, rank)
     rank = 0
 #endif
 
-end subroutine get_block_iteration_params
+  end subroutine get_block_iteration_params
+
 end module biocfd_mpi_helpers

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -116,8 +116,6 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     !> This is blocks per GPU computed as nblocks / total_gpus (real
     !> as in a floating point number)
     real(real32) :: real_blocks_per_gpu
-    ! Looping variable
-    integer:: i
 
     call MPI_Comm_size(MPI_COMM_WORLD, world_size, ierror)
     call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -8,7 +8,7 @@ module biocfd_mpi_helpers
                      MPI_Finalize, MPI_Init_Thread, MPI_IN_PLACE, MPI_INTEGER, MPI_THREAD_SERIALIZED
 #endif
 #ifdef _OPENACC
-  use openacc, only: acc_device_default, acc_get_num_devices
+  use openacc, only: acc_device_default, acc_device_host, acc_get_num_devices, acc_set_device_type
 #endif
 
   implicit none
@@ -139,10 +139,17 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
 
     rank_gpus(rank + 1) = acc_get_num_devices(acc_device_default)
 
+    ! The device type is set to the host due a crash that has been
+    ! seen in the AllGather operation. It seems that CUDA-aware MPI
+    ! can start doing things on the GPU that we don't really want it
+    ! to. Setting the device type to host here (and then back to the
+    ! GPU once the AllGather is complete) seems to not crash.
+    call acc_set_device_type(acc_device_host)
     ! Gather all GPUs together such that every rank has an array of
     ! GPU numbers
     call MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, rank_gpus, 1, MPI_INTEGER, &
                        MPI_COMM_WORLD, ierror)
+    call acc_set_device_type(acc_device_default)
     total_gpus = sum(rank_gpus)
 
     ! This is how many blocks we need to have per GPU

--- a/src/mpi_helpers.f90
+++ b/src/mpi_helpers.f90
@@ -55,7 +55,7 @@ contains
        stop 1
     end if
 #endif
-    call  get_block_iteration_params(nblocks, start, finish, step, rank)
+    call  get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
   end subroutine biocfd_init
 
   !> Finalize is an no-op in the case that we aren't using MPI
@@ -117,7 +117,7 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
 
     integer :: world_size
     integer, allocatable :: rank_gpus(:), rank_blocks(:)
-    integer :: total_gpus
+    integer :: this_rank_gpus, total_gpus
     !> This is blocks per GPU computed as nblocks / total_gpus (real
     !> as in a floating point number)
     real(real32) :: real_blocks_per_gpu
@@ -137,12 +137,18 @@ subroutine get_block_iteration_params_gpu(nblocks, start, finish, step, rank)
     ! split blocks fractionally
     allocate(ideal_blocks(world_size))
 
-    rank_gpus(rank + 1) = acc_get_num_devices(acc_device_default)
+    this_rank_gpus = acc_get_num_devices(acc_device_default)
 
     ! Gather all GPUs together such that every rank has an array of
     ! GPU numbers
-    call MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, rank_gpus, 1, MPI_INTEGER, &
-                       MPI_COMM_WORLD, ierror)
+    !
+    ! Note that really we want to use AllGather here, but we ran into
+    ! crashes, which seemed to be related to CUDA-aware MPI. Gather
+    ! and Bcast is potentially slower, but this isn't a performance
+    ! critical part of the code
+    call MPI_Gather(this_rank_gpus, 1, MPI_INTEGER, rank_gpus, 1, MPI_INTEGER, 0, &
+         MPI_COMM_WORLD, ierror)
+    call MPI_Bcast(rank_gpus, world_size, MPI_INTEGER, 0, MPI_COMM_WORLD, ierror)
     total_gpus = sum(rank_gpus)
 
     ! This is how many blocks we need to have per GPU


### PR DESCRIPTION
Tries to split work across nodes based on the GPUs available. 

For example, say we have 5 GPUs, with 4 on rank 0 and 1 on rank 1, and 10 blocks. This should work out that we have 5 GPUs in total, meaning we need 2 blocks per GPU. We should end up with 8 blocks on rank 0 and 2 blocks on rank 1.

~It should also deal with cases where blocks / GPUs isn't a round number. E.g. 11 blocks instead of 10 would lead to 2.2 blocks per GPU -> 8.8 blocks on rank 0 (gets rounded to 9) and 2.2 blocks on rank 1 (gets rounded to 2).~

~If we get a situation where there are multiple `x.5` values, then we trim off the last rank e.g. 10 blocks, 4 GPUs across 3 ranks (2, 1, 1), then we'd get 2.5 blocks per GPU, which would result in (5, 3, 3) blocks on ranks (0, 1, 2). In that case the upper bound is clamped such that we end up with (5, 3, 2).~

Cases where blocks / GPUs isn't a round number are dealt with using a "largest-remainder method".

There are probably more situations I've not considered.
