### PR TITLE
Add Hdf5 reader subroutines

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,7 +1,7 @@
 name = "Bio-CFD"
 # To use HDF5 uncomment the dependencies.hdf5 line below and set
 # USE_HDF5=1
-# dependencies.hdf5 = "*"
+dependencies.hdf5 = "*"
 version = "0.1.0"
 [build]
 auto-executables = true
@@ -10,7 +10,7 @@ auto-examples = true
 external-modules = ["hdf5", "openacc", "mpi_f08"]
 
 [preprocess]
-cpp.macros = ["USE_HDF5=0"]
+cpp.macros = ["USE_HDF5=1"]
 
 
 [install]

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,7 +1,7 @@
 name = "Bio-CFD"
 # To use HDF5 uncomment the dependencies.hdf5 line below and set
 # USE_HDF5=1
-dependencies.hdf5 = "*"
+# dependencies.hdf5 = "*"
 version = "0.1.0"
 [build]
 auto-executables = true
@@ -10,7 +10,7 @@ auto-examples = true
 external-modules = ["hdf5", "openacc", "mpi_f08"]
 
 [preprocess]
-cpp.macros = ["USE_HDF5=1"]
+cpp.macros = ["USE_HDF5=0"]
 
 
 [install]

--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -14,9 +14,9 @@ module biocfd_hdf5_io
 
   private
 
-  public :: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, hdf5_read_real_2d!, &
-       !hdf5_read_real_1d, hdf5_read_real_scalar, hdf5_read_int_3d, hdf5_read_int_2d, &
-       !hdf5_read_int_1d, hdf5_read_int_scalar
+  public :: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, hdf5_read_real_2d, &
+       hdf5_read_real_1d, hdf5_read_int_3d!, hdf5_read_int_2d, &
+       !hdf5_read_int_1d
 contains
 
   subroutine hdf5_read_real_3d(filename, group, key, output)
@@ -50,6 +50,37 @@ contains
 
   end subroutine hdf5_read_real_3d
 
+  subroutine hdf5_read_int_3d(filename, group, key, output)
+    integer :: error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(3) :: dims, maxdims
+    character(len=*), intent(in) :: filename
+    character(len=*), intent(in) :: group
+    character(len=*), intent(in) :: key
+
+    integer(int64), allocatable, intent(out) :: output(:,:,:)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(output(dims(1), dims(2), dims(3)))
+
+    call h5dread_f(dset_id, H5T_STD_I64LE, output, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+  end subroutine hdf5_read_int_3d
+  
   subroutine hdf5_read_real_2d(filename, group, key, output)
     integer :: error_hdf5
     integer(hid_t) :: file_id, dset_id, dspace_id
@@ -81,6 +112,37 @@ contains
 
   end subroutine hdf5_read_real_2d
 
+  subroutine hdf5_read_real_1d(filename, group, key, output)
+    integer :: error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(1) :: dims, maxdims
+    character(len=*), intent(in) :: filename
+    character(len=*), intent(in) :: group
+    character(len=*), intent(in) :: key
+
+    real(dp), allocatable, intent(out) :: output(:)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(output(dims(1)))
+
+    call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, output, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+  end subroutine hdf5_read_real_1d
+  
   subroutine hdf5_write_real(filename,scalar_input,&
                              array_input_1d,array_input_2d,array_input_3d,key,group)
 

--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -9,14 +9,15 @@ module biocfd_hdf5_io
        h5dwrite_f, h5dclose_f, h5sclose_f, h5gclose_f, h5fclose_f, h5close_f, &
        h5F_acc_rdwr_f, H5S_SCALAR_F, H5T_STD_I64LE, h5f_acc_excl_f, h5t_native_double, &
        h5acreate_f, h5awrite_f, size_t, h5aclose_f, h5sclose_f, H5F_ACC_RDONLY_F, &
-       h5dopen_f, h5dget_space_f, h5sget_simple_extent_dims_f, h5dread_f
+       h5dopen_f, h5dget_space_f, h5sget_simple_extent_dims_f, h5dread_f, &
+       h5aopen_name_f, h5aread_f
   implicit none
 
   private
 
   public :: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, hdf5_read_real_2d, &
        hdf5_read_real_1d, hdf5_read_int_3d, hdf5_read_int_2d, &
-       hdf5_read_int_1d
+       hdf5_read_int_1d, hdf5_read_real_scalar
 contains
 
   subroutine hdf5_read_real_3d(filename, group, key, output)
@@ -204,6 +205,34 @@ contains
     call h5close_f(error_hdf5)
 
   end subroutine hdf5_read_int_1d
+
+  subroutine hdf5_read_real_scalar(filename, group, key, output)
+    integer :: error_hdf5
+    integer(hid_t) :: file_id, group_id, attr_id, attr_space_id
+    INTEGER(HSIZE_T), DIMENSION(1) :: adims
+    character(len=*), intent(in) :: filename
+    character(len=*), intent(in) :: group
+    character(len=*), intent(in) :: key
+
+    real(dp), intent(out) :: output
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5gopen_f(file_id, group, group_id, error_hdf5)
+
+    call h5aopen_name_f(group_id, key, attr_id, error_hdf5)
+
+
+    call h5aread_f(attr_id, H5T_NATIVE_DOUBLE, output, adims, error_hdf5)
+
+    call h5aclose_f(attr_id, error_hdf5)
+    call h5gclose_f(group_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+  end subroutine hdf5_read_real_scalar
   
   subroutine hdf5_write_real(filename,scalar_input,&
                              array_input_1d,array_input_2d,array_input_3d,key,group)

--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -81,7 +81,7 @@ contains
     call h5close_f(error_hdf5)
 
   end subroutine hdf5_read_int_3d
-  
+
   subroutine hdf5_read_real_2d(filename, group, key, output)
     integer :: error_hdf5
     integer(hid_t) :: file_id, dset_id, dspace_id
@@ -143,7 +143,7 @@ contains
     call h5close_f(error_hdf5)
 
   end subroutine hdf5_read_int_2d
-  
+
   subroutine hdf5_read_real_1d(filename, group, key, output)
     integer :: error_hdf5
     integer(hid_t) :: file_id, dset_id, dspace_id
@@ -259,7 +259,7 @@ contains
     call h5close_f(error_hdf5)
 
   end subroutine hdf5_read_int_scalar
-  
+
   subroutine hdf5_write_real(filename,scalar_input,&
                              array_input_1d,array_input_2d,array_input_3d,key,group)
 

--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -15,8 +15,8 @@ module biocfd_hdf5_io
   private
 
   public :: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, hdf5_read_real_2d, &
-       hdf5_read_real_1d, hdf5_read_int_3d, hdf5_read_int_2d!, &
-       !hdf5_read_int_1d
+       hdf5_read_real_1d, hdf5_read_int_3d, hdf5_read_int_2d, &
+       hdf5_read_int_1d
 contains
 
   subroutine hdf5_read_real_3d(filename, group, key, output)
@@ -173,6 +173,37 @@ contains
     call h5close_f(error_hdf5)
 
   end subroutine hdf5_read_real_1d
+
+  subroutine hdf5_read_int_1d(filename, group, key, output)
+    integer :: error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(1) :: dims, maxdims
+    character(len=*), intent(in) :: filename
+    character(len=*), intent(in) :: group
+    character(len=*), intent(in) :: key
+
+    integer(int64), allocatable, intent(out) :: output(:)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(output(dims(1)))
+
+    call h5dread_f(dset_id, H5T_STD_I64LE, output, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+  end subroutine hdf5_read_int_1d
   
   subroutine hdf5_write_real(filename,scalar_input,&
                              array_input_1d,array_input_2d,array_input_3d,key,group)

--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -8,14 +8,48 @@ module biocfd_hdf5_io
        h5gcreate_f, h5gopen_f, h5screate_f, h5screate_simple_f, h5dcreate_f, &
        h5dwrite_f, h5dclose_f, h5sclose_f, h5gclose_f, h5fclose_f, h5close_f, &
        h5F_acc_rdwr_f, H5S_SCALAR_F, H5T_STD_I64LE, h5f_acc_excl_f, h5t_native_double, &
-       h5acreate_f, h5awrite_f, size_t, h5aclose_f, h5sclose_f
+       h5acreate_f, h5awrite_f, size_t, h5aclose_f, h5sclose_f, H5F_ACC_RDONLY_F, &
+       h5dopen_f, h5dget_space_f, h5sget_simple_extent_dims_f, h5dread_f
   implicit none
 
   private
 
-  public :: hdf5_write_real, hdf5_write_int
+  public :: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d!, hdf5_read_real_2d, &
+       !hdf5_read_real_1d, hdf5_read_real_scalar, hdf5_read_int_3d, hdf5_read_int_2d, &
+       !hdf5_read_int_1d, hdf5_read_int_scalar
 contains
 
+  subroutine hdf5_read_real_3d(filename, group, key, output)
+    integer :: error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(3) :: dims, maxdims
+    character(len=*), intent(in) :: filename
+    character(len=*), intent(in) :: group
+    character(len=*), intent(in) :: key
+
+    real(dp), allocatable, intent(out) :: output(:,:,:)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(output(dims(1), dims(2), dims(3)))
+
+    call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, output, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+  end subroutine hdf5_read_real_3d
+  
   subroutine hdf5_write_real(filename,scalar_input,&
                              array_input_1d,array_input_2d,array_input_3d,key,group)
 

--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -17,7 +17,7 @@ module biocfd_hdf5_io
 
   public :: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, hdf5_read_real_2d, &
        hdf5_read_real_1d, hdf5_read_int_3d, hdf5_read_int_2d, &
-       hdf5_read_int_1d, hdf5_read_real_scalar
+       hdf5_read_int_1d, hdf5_read_real_scalar, hdf5_read_int_scalar
 contains
 
   subroutine hdf5_read_real_3d(filename, group, key, output)
@@ -224,7 +224,6 @@ contains
 
     call h5aopen_name_f(group_id, key, attr_id, error_hdf5)
 
-
     call h5aread_f(attr_id, H5T_NATIVE_DOUBLE, output, adims, error_hdf5)
 
     call h5aclose_f(attr_id, error_hdf5)
@@ -233,6 +232,33 @@ contains
     call h5close_f(error_hdf5)
 
   end subroutine hdf5_read_real_scalar
+
+  subroutine hdf5_read_int_scalar(filename, group, key, output)
+    integer :: error_hdf5
+    integer(hid_t) :: file_id, group_id, attr_id, attr_space_id
+    INTEGER(HSIZE_T), DIMENSION(1) :: adims
+    character(len=*), intent(in) :: filename
+    character(len=*), intent(in) :: group
+    character(len=*), intent(in) :: key
+
+    integer(int64), intent(out) :: output
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5gopen_f(file_id, group, group_id, error_hdf5)
+
+    call h5aopen_name_f(group_id, key, attr_id, error_hdf5)
+
+    call h5aread_f(attr_id, H5T_STD_I64LE, output, adims, error_hdf5)
+
+    call h5aclose_f(attr_id, error_hdf5)
+    call h5gclose_f(group_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+  end subroutine hdf5_read_int_scalar
   
   subroutine hdf5_write_real(filename,scalar_input,&
                              array_input_1d,array_input_2d,array_input_3d,key,group)

--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -14,7 +14,7 @@ module biocfd_hdf5_io
 
   private
 
-  public :: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d!, hdf5_read_real_2d, &
+  public :: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, hdf5_read_real_2d!, &
        !hdf5_read_real_1d, hdf5_read_real_scalar, hdf5_read_int_3d, hdf5_read_int_2d, &
        !hdf5_read_int_1d, hdf5_read_int_scalar
 contains
@@ -49,7 +49,38 @@ contains
     call h5close_f(error_hdf5)
 
   end subroutine hdf5_read_real_3d
-  
+
+  subroutine hdf5_read_real_2d(filename, group, key, output)
+    integer :: error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(2) :: dims, maxdims
+    character(len=*), intent(in) :: filename
+    character(len=*), intent(in) :: group
+    character(len=*), intent(in) :: key
+
+    real(dp), allocatable, intent(out) :: output(:,:)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(output(dims(1), dims(2)))
+
+    call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, output, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+  end subroutine hdf5_read_real_2d
+
   subroutine hdf5_write_real(filename,scalar_input,&
                              array_input_1d,array_input_2d,array_input_3d,key,group)
 

--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -15,7 +15,7 @@ module biocfd_hdf5_io
   private
 
   public :: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, hdf5_read_real_2d, &
-       hdf5_read_real_1d, hdf5_read_int_3d!, hdf5_read_int_2d, &
+       hdf5_read_real_1d, hdf5_read_int_3d, hdf5_read_int_2d!, &
        !hdf5_read_int_1d
 contains
 
@@ -112,6 +112,37 @@ contains
 
   end subroutine hdf5_read_real_2d
 
+  subroutine hdf5_read_int_2d(filename, group, key, output)
+    integer :: error_hdf5
+    integer(hid_t) :: file_id, dset_id, dspace_id
+    integer(hsize_t), dimension(2) :: dims, maxdims
+    character(len=*), intent(in) :: filename
+    character(len=*), intent(in) :: group
+    character(len=*), intent(in) :: key
+
+    integer(int64), allocatable, intent(out) :: output(:,:)
+
+    call h5open_f(error_hdf5)
+
+    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
+
+    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
+
+    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
+
+    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
+
+    allocate(output(dims(1), dims(2)))
+
+    call h5dread_f(dset_id, H5T_STD_I64LE, output, dims, error_hdf5)
+
+    call h5dclose_f(dset_id, error_hdf5)
+    call h5sclose_f(dspace_id, error_hdf5)
+    call h5fclose_f(file_id, error_hdf5)
+    call h5close_f(error_hdf5)
+
+  end subroutine hdf5_read_int_2d
+  
   subroutine hdf5_read_real_1d(filename, group, key, output)
     integer :: error_hdf5
     integer(hid_t) :: file_id, dset_id, dspace_id

--- a/test/test_hdf5_io.f90
+++ b/test/test_hdf5_io.f90
@@ -4,7 +4,7 @@ module test_hdf5_io
   use testdrive, only : error_type, unittest_type, new_unittest, check
   use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, &
        hdf5_read_real_2d, hdf5_read_real_1d, hdf5_read_int_3d, hdf5_read_int_2d, &
-       hdf5_read_int_1d, hdf5_read_real_scalar
+       hdf5_read_int_1d, hdf5_read_real_scalar, hdf5_read_int_scalar
   use hdf5, only: hid_t, hsize_t, h5f_acc_rdonly_f, h5t_std_i64le, &
        h5t_native_double, h5aread_f, h5dread_f, h5aclose_f, h5aopen_name_f, &
        h5dclose_f, h5close_f, h5dget_space_f, h5dopen_f, h5fclose_f, &
@@ -268,21 +268,7 @@ contains
 
     call hdf5_write_int(filename=filename, scalar_input=scalar, key=key, group=group)
 
-    call h5open_f(error_hdf5)
-
-    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
-
-    call h5gopen_f(file_id, group, group_id, error_hdf5)
-
-    call h5aopen_name_f(group_id, key, attr_id, error_hdf5)
-
-
-    call h5aread_f(attr_id, H5T_STD_I64LE, scalar_read, adims, error_hdf5)
-
-    call h5aclose_f(attr_id, error_hdf5)
-    call h5gclose_f(group_id, error_hdf5)
-    call h5fclose_f(file_id, error_hdf5)
-    call h5close_f(error_hdf5)
+    call hdf5_read_int_scalar(filename=filename, group=group, key=key, output=scalar_read)
 
     call check(error, scalar , scalar_read)
     if (allocated(error)) return

--- a/test/test_hdf5_io.f90
+++ b/test/test_hdf5_io.f90
@@ -3,7 +3,8 @@ module test_hdf5_io
   use, intrinsic :: iso_fortran_env, only: int64, dp =>real64
   use testdrive, only : error_type, unittest_type, new_unittest, check
   use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, &
-       hdf5_read_real_2d, hdf5_read_real_1d, hdf5_read_int_3d, hdf5_read_int_2d
+       hdf5_read_real_2d, hdf5_read_real_1d, hdf5_read_int_3d, hdf5_read_int_2d, &
+       hdf5_read_int_1d
   use hdf5, only: hid_t, hsize_t, h5f_acc_rdonly_f, h5t_std_i64le, &
        h5t_native_double, h5aread_f, h5dread_f, h5aclose_f, h5aopen_name_f, &
        h5dclose_f, h5close_f, h5dget_space_f, h5dopen_f, h5fclose_f, &
@@ -255,24 +256,7 @@ contains
 
     call hdf5_write_int(filename=filename, array_input_1d=array1d, key=key, group=group)
 
-    call h5open_f(error_hdf5)
-
-    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
-
-    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
-
-    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
-
-    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
-
-    allocate(array1d_read(dims(1)))
-
-    call h5dread_f(dset_id, H5T_STD_I64LE, array1d_read, dims, error_hdf5)
-
-    call h5dclose_f(dset_id, error_hdf5)
-    call h5sclose_f(dspace_id, error_hdf5)
-    call h5fclose_f(file_id, error_hdf5)
-    call h5close_f(error_hdf5)
+    call hdf5_read_int_1d(filename=filename, group=group, key=key, output=array1d_read)
 
     arrays_equal = all(array1d_read == array1d)
 

--- a/test/test_hdf5_io.f90
+++ b/test/test_hdf5_io.f90
@@ -3,7 +3,7 @@ module test_hdf5_io
   use, intrinsic :: iso_fortran_env, only: int64, dp =>real64
   use testdrive, only : error_type, unittest_type, new_unittest, check
   use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, &
-       hdf5_read_real_2d, hdf5_read_real_1d, hdf5_read_int_3d
+       hdf5_read_real_2d, hdf5_read_real_1d, hdf5_read_int_3d, hdf5_read_int_2d
   use hdf5, only: hid_t, hsize_t, h5f_acc_rdonly_f, h5t_std_i64le, &
        h5t_native_double, h5aread_f, h5dread_f, h5aclose_f, h5aopen_name_f, &
        h5dclose_f, h5close_f, h5dget_space_f, h5dopen_f, h5fclose_f, &
@@ -225,24 +225,7 @@ contains
 
     call hdf5_write_int(filename=filename, array_input_2d=array2d, key=key, group=group)
 
-    call h5open_f(error_hdf5)
-
-    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
-
-    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
-
-    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
-
-    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
-
-    allocate(array2d_read(dims(1), dims(2)))
-
-    call h5dread_f(dset_id, H5T_STD_I64LE, array2d_read, dims, error_hdf5)
-
-    call h5dclose_f(dset_id, error_hdf5)
-    call h5sclose_f(dspace_id, error_hdf5)
-    call h5fclose_f(file_id, error_hdf5)
-    call h5close_f(error_hdf5)
+    call hdf5_read_int_2d(filename=filename, group=group, key=key, output=array2d_read)
 
     arrays_equal = all(array2d_read == array2d)
 

--- a/test/test_hdf5_io.f90
+++ b/test/test_hdf5_io.f90
@@ -2,7 +2,7 @@
 module test_hdf5_io
   use, intrinsic :: iso_fortran_env, only: int64, dp =>real64
   use testdrive, only : error_type, unittest_type, new_unittest, check
-  use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int
+  use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d
   use hdf5, only: hid_t, hsize_t, h5f_acc_rdonly_f, h5t_std_i64le, &
        h5t_native_double, h5aread_f, h5dread_f, h5aclose_f, h5aopen_name_f, &
        h5dclose_f, h5close_f, h5dget_space_f, h5dopen_f, h5fclose_f, &
@@ -58,24 +58,7 @@ contains
 
     call hdf5_write_real(filename=filename, array_input_3d=array3d, key=key, group=group)
 
-    call h5open_f(error_hdf5)
-
-    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
-
-    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
-
-    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
-
-    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
-
-    allocate(array3d_read(dims(1), dims(2), dims(3)))
-
-    call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, array3d_read, dims, error_hdf5)
-
-    call h5dclose_f(dset_id, error_hdf5)
-    call h5sclose_f(dspace_id, error_hdf5)
-    call h5fclose_f(file_id, error_hdf5)
-    call h5close_f(error_hdf5)
+    call hdf5_read_real_3d(filename=filename, group=group, key=key, output=array3d_read)
 
     arrays_equal = all(array3d_read == array3d)
 

--- a/test/test_hdf5_io.f90
+++ b/test/test_hdf5_io.f90
@@ -3,7 +3,7 @@ module test_hdf5_io
   use, intrinsic :: iso_fortran_env, only: int64, dp =>real64
   use testdrive, only : error_type, unittest_type, new_unittest, check
   use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, &
-       hdf5_read_real_2d
+       hdf5_read_real_2d, hdf5_read_real_1d, hdf5_read_int_3d
   use hdf5, only: hid_t, hsize_t, h5f_acc_rdonly_f, h5t_std_i64le, &
        h5t_native_double, h5aread_f, h5dread_f, h5aclose_f, h5aopen_name_f, &
        h5dclose_f, h5close_f, h5dget_space_f, h5dopen_f, h5fclose_f, &
@@ -121,24 +121,7 @@ contains
 
     call hdf5_write_real(filename=filename, array_input_1d=array1d, key=key, group=group)
 
-    call h5open_f(error_hdf5)
-
-    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
-
-    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
-
-    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
-
-    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
-
-    allocate(array1d_read(dims(1)))
-
-    call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, array1d_read, dims, error_hdf5)
-
-    call h5dclose_f(dset_id, error_hdf5)
-    call h5sclose_f(dspace_id, error_hdf5)
-    call h5fclose_f(file_id, error_hdf5)
-    call h5close_f(error_hdf5)
+    call hdf5_read_real_1d(filename=filename, group=group, key=key, output=array1d_read)
 
     arrays_equal = all(array1d_read == array1d)
 
@@ -210,24 +193,7 @@ contains
 
     call hdf5_write_int(filename=filename, array_input_3d=array3d, key=key, group=group)
 
-    call h5open_f(error_hdf5)
-
-    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
-
-    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
-
-    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
-
-    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
-
-    allocate(array3d_read(dims(1), dims(2), dims(3)))
-
-    call h5dread_f(dset_id, H5T_STD_I64LE, array3d_read, dims, error_hdf5)
-
-    call h5dclose_f(dset_id, error_hdf5)
-    call h5sclose_f(dspace_id, error_hdf5)
-    call h5fclose_f(file_id, error_hdf5)
-    call h5close_f(error_hdf5)
+    call hdf5_read_int_3d(filename=filename, group=group, key=key, output=array3d_read)
 
     arrays_equal = all(array3d_read == array3d)
 

--- a/test/test_hdf5_io.f90
+++ b/test/test_hdf5_io.f90
@@ -2,7 +2,8 @@
 module test_hdf5_io
   use, intrinsic :: iso_fortran_env, only: int64, dp =>real64
   use testdrive, only : error_type, unittest_type, new_unittest, check
-  use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d
+  use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, &
+       hdf5_read_real_2d
   use hdf5, only: hid_t, hsize_t, h5f_acc_rdonly_f, h5t_std_i64le, &
        h5t_native_double, h5aread_f, h5dread_f, h5aclose_f, h5aopen_name_f, &
        h5dclose_f, h5close_f, h5dget_space_f, h5dopen_f, h5fclose_f, &
@@ -90,24 +91,7 @@ contains
 
     call hdf5_write_real(filename=filename, array_input_2d=array2d, key=key, group=group)
 
-    call h5open_f(error_hdf5)
-
-    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
-
-    call h5dopen_f(file_id, trim(group)//"/"//trim(key), dset_id, error_hdf5)
-
-    call h5dget_space_f(dset_id, dspace_id, error_hdf5)
-
-    call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, error_hdf5)
-
-    allocate(array2d_read(dims(1), dims(2)))
-
-    call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, array2d_read, dims, error_hdf5)
-
-    call h5dclose_f(dset_id, error_hdf5)
-    call h5sclose_f(dspace_id, error_hdf5)
-    call h5fclose_f(file_id, error_hdf5)
-    call h5close_f(error_hdf5)
+    call hdf5_read_real_2d(filename=filename, group=group, key=key, output=array2d_read)
 
     arrays_equal = all(array2d_read == array2d)
 

--- a/test/test_hdf5_io.f90
+++ b/test/test_hdf5_io.f90
@@ -4,7 +4,7 @@ module test_hdf5_io
   use testdrive, only : error_type, unittest_type, new_unittest, check
   use biocfd_hdf5_io, only: hdf5_write_real, hdf5_write_int, hdf5_read_real_3d, &
        hdf5_read_real_2d, hdf5_read_real_1d, hdf5_read_int_3d, hdf5_read_int_2d, &
-       hdf5_read_int_1d
+       hdf5_read_int_1d, hdf5_read_real_scalar
   use hdf5, only: hid_t, hsize_t, h5f_acc_rdonly_f, h5t_std_i64le, &
        h5t_native_double, h5aread_f, h5dread_f, h5aclose_f, h5aopen_name_f, &
        h5dclose_f, h5close_f, h5dget_space_f, h5dopen_f, h5fclose_f, &
@@ -148,21 +148,7 @@ contains
 
     call hdf5_write_real(filename=filename, scalar_input=scalar, key=key, group=group)
 
-    call h5open_f(error_hdf5)
-
-    call h5fopen_f(filename, H5F_ACC_RDONLY_F, file_id, error_hdf5)
-
-    call h5gopen_f(file_id, group, group_id, error_hdf5)
-
-    call h5aopen_name_f(group_id, key, attr_id, error_hdf5)
-
-
-    call h5aread_f(attr_id, H5T_NATIVE_DOUBLE, scalar_read, adims, error_hdf5)
-
-    call h5aclose_f(attr_id, error_hdf5)
-    call h5gclose_f(group_id, error_hdf5)
-    call h5fclose_f(file_id, error_hdf5)
-    call h5close_f(error_hdf5)
+    call hdf5_read_real_scalar(filename=filename, group=group, key=key, output=scalar_read)
 
     call check(error, scalar , scalar_read)
     if (allocated(error)) return


### PR DESCRIPTION
This PR adds the ability to read 3d,2d,1d and scalar arrays from hdf5 files for both integer and real types.