### PR TITLE
Remove unneeded reallocations of e.g. cent arrays

### DIFF
--- a/app/main.F90
+++ b/app/main.F90
@@ -170,9 +170,6 @@ PROGRAM main
        do g=start, finish, step
          if (g /= 1) then
            !$acc wait
-           DEALLOCATE(block(g)%xcent, block(g)%ycent, block(g)%zcent, &
-                      block(g)%cosAlpha, block(g)%cosBeta, block(g)%cosGamma, &
-                      block(g)%element_length)
            block(g)%blk_mv_tag=0.
            CALL computeSurfaceVariables(block(g),g,phase_angle,piv_pt)
          end if

--- a/src/AllocateArrays.f90
+++ b/src/AllocateArrays.f90
@@ -44,6 +44,13 @@ module biocfd_allocate_arrays
         ALLOCATE(blk%Acx(nx,3), blk%Acy(ny,3), blk%Acz(nz,3))
         ALLOCATE(blk%pc(nx+2,ny+2, nz+2), blk%pco(nx+2,ny+2, nz+2))
 
+        ALLOCATE(blk%xcent(blk%ibElems), &
+                 blk%ycent(blk%ibElems), &
+                 blk%zcent(blk%ibElems), &
+                 blk%cosAlpha(blk%ibElems), &
+                 blk%cosBeta(blk%ibElems), &
+                 blk%cosGamma(blk%ibElems), &
+                 blk%element_length(blk%ibElems))
 
       END SUBROUTINE allocateArrays
 end module biocfd_allocate_arrays

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -212,12 +212,6 @@ module biocfd_search
         REAL(dp)      :: p1x, p1y, p1z, p2x, p2y, p2z, p3x, p3y, p3z, lenEL
         REAL(dp)      :: var_xcent, var_ycent, var_zcent
 
-        ALLOCATE (blk%xcent(blk%ibElems), blk%ycent(blk%ibElems), &
-                  blk%zcent(blk%ibElems), &
-                  blk%cosAlpha(blk%ibElems), blk%cosBeta(blk%ibElems), &
-                  blk%cosGamma(blk%ibElems), &
-                  blk%element_length(blk%ibElems))
-
         !compute centroid and direction cosines
        !$acc parallel loop gang vector default(present) &
        !$acc private (var_xcent, var_ycent, var_zcent,p1x, p1y, p1z, p2x, p2y, p2z, p3x, p3y, p3z, lenEL) &


### PR DESCRIPTION
Closes #226.

If I'm reading the code right, `ibElems` never changes, so there is no need to keep allocating/deallocating these arrays every iteration.

If someone else could carefully check that my logic is right that would be great!