### PR TITLE
Make nvhpc ci job build with mpi

### DIFF
--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -67,6 +67,14 @@ jobs:
           # Install hdf5 dependency
           sudo apt install libhdf5-dev
 
+      - name: Modify FPM_FFLAGS to include mpi flags nvhpc
+        if: ${{ contains(matrix.toolchain.compiler, 'nvidia-hpc') }}
+        run: |
+          export MPI_FLAGS=$(mpif90 -show | cut -d' ' -f2-)
+          export FPM_FFLAGS="$MPI_FLAGS $FPM_FFLAGS"
+          echo "FPM_FFLAGS=$FPM_FFLAGS" >> $GITHUB_ENV
+          sed -i 's/"USE_HDF5=0"/"USE_HDF5=0","BIOCFD_MPI"/' fpm.toml
+
       - run: |
           # Build and test code using FPM
           fpm test


### PR DESCRIPTION
This PR makes the nvhpc ci job build Bio-CFD with mpi. This is done by appending to FPM_FFLAGS the flags for the mpif90 compiler, and by adding BIOCFD_MPI to the proprocessor macros in the fpm.toml (done this way to avoid mpi builds being the default.