### PR TITLE
Add docstrings to Blocks

### DIFF
--- a/src/Blocks.f90
+++ b/src/Blocks.f90
@@ -1,78 +1,78 @@
 MODULE biocfd_block_type
-       use, intrinsic :: iso_fortran_env, only: dp => real64, int32, int64
-       IMPLICIT NONE
-       private
+  use, intrinsic :: iso_fortran_env, only: dp => real64, int32, int64
+  IMPLICIT NONE
+  private
 
-       public :: Block_t
+  public :: Block_t
 
-        type Block_t
-           REAL(dp) ::  dx,dy, dz, ypth2, xpth1, xpth2, xchg,ychg, yt, ydot, yddot,&
-                bfreq, yamp, xt, xdot
-        REAL(dp) :: derr1,derr2,derrStdSt,a0
-        REAL(dp) :: xshift, yshift, zshift, gx_shift, gy_shift,gz_shift
-        INTEGER (int64) :: nx, ny, nz
-        INTEGER (int64) :: mk, mkx1, mkx2
-        INTEGER (int64) :: nIterPcor, cintp, fineg
-        INTEGER (int64) ::  k_startSearch, k_endSearch, &
-                                     j_startSearch, j_endSearch, &
-                                     i_startSearch, i_endSearch
-       INTEGER (int64), ALLOCATABLE, DIMENSION (:,:,:) :: cell, cell2, cell_n, cell_pr,nodeIdTag
+  type Block_t
+     REAL(dp) ::  dx,dy, dz, ypth2, xpth1, xpth2, xchg,ychg, yt, ydot, yddot,&
+          bfreq, yamp, xt, xdot
+     REAL(dp) :: derr1,derr2,derrStdSt,a0
+     REAL(dp) :: xshift, yshift, zshift, gx_shift, gy_shift,gz_shift
+     INTEGER (int64) :: nx, ny, nz
+     INTEGER (int64) :: mk, mkx1, mkx2
+     INTEGER (int64) :: nIterPcor, cintp, fineg
+     INTEGER (int64) ::  k_startSearch, k_endSearch, &
+          j_startSearch, j_endSearch, &
+          i_startSearch, i_endSearch
+     INTEGER (int64), ALLOCATABLE, DIMENSION (:,:,:) :: cell, cell2, cell_n, cell_pr,nodeIdTag
 
-       REAL (dp), ALLOCATABLE, DIMENSION (:) :: deltax, deltay, deltaz, x1, y1, z1, &
-            xu, yu, zu, xv, yv, zv, xw, yw, zw, xp, yp, zp
+     REAL (dp), ALLOCATABLE, DIMENSION (:) :: deltax, deltay, deltaz, x1, y1, z1, &
+          xu, yu, zu, xv, yv, zv, xw, yw, zw, xp, yp, zp
 
-       real(dp), allocatable, dimension(:, :) :: ca_uu, ck_uu, ca_vv, ck_vv, ca_ww, ck_ww, &
-                                                 ca_uv, ck_uv, ca_uw, ck_uw, ca_vu, ck_vu, &
-                                                 ca_vw, ck_vw, ca_wu, ck_wu, ca_wv, ck_wv
-
-
-       REAL (dp), ALLOCATABLE, DIMENSION (:, :)    :: Acx, Acy, Acz
-       REAL (dp), ALLOCATABLE, DIMENSION (:, :, :) :: b, u, u_dum, ut, &
-                                                      v, vt, v_dum, &
-                                                      w, wt, w_dum, &
-                                                      p, p_dum, pc, pco
-
-        INTEGER (int64), ALLOCATABLE, DIMENSION (:, :) :: fluidIndexPtr, redCellIndexPtr, &
-                                                          blackCellIndexPtr, nodeId
-        INTEGER(int64) :: ibCellCount, solidCellCount, fluidCellCount, redCellCount, &
-                          blackCellCount, TSCellCount
-
-       INTEGER (int64), ALLOCATABLE, DIMENSION (:, :) :: TSIndexPtr, interceptedIndexPtr, &
-                                                         solidIndexPtr
+     real(dp), allocatable, dimension(:, :) :: ca_uu, ck_uu, ca_vv, ck_vv, ca_ww, ck_ww, &
+          ca_uv, ck_uv, ca_uw, ck_uw, ca_vu, ck_vu, &
+          ca_vw, ck_vw, ca_wu, ck_wu, ca_wv, ck_wv
 
 
-       INTEGER (int64), ALLOCATABLE, DIMENSION (:) :: nelp, nelu1, nelu2, nelv1, nelv2, nelw1, nelw2
-       REAL (dp), ALLOCATABLE, DIMENSION (:) :: xcent, ycent, zcent, &
-                                                cosAlpha, cosBeta, cosGamma, &
-                                                element_length, &
-                                                pNormDis, u1NormDis, u2NormDis , &
-                                                v1NormDis, v2NormDis, w1NormDis, w2NormDis, &
-                                                p_ghost, pt_ghost, u2_ghost, u2t_ghost, &
-                                                v2_ghost, v2t_ghost, w2_ghost, &
-                                                w2t_ghost, u1_ghost, u1t_ghost, &
-                                                v1_ghost, v1t_ghost, w1_ghost, w1t_ghost
+     REAL (dp), ALLOCATABLE, DIMENSION (:, :)    :: Acx, Acy, Acz
+     REAL (dp), ALLOCATABLE, DIMENSION (:, :, :) :: b, u, u_dum, ut, &
+          v, vt, v_dum, &
+          w, wt, w_dum, &
+          p, p_dum, pc, pco
 
-       INTEGER (int64), ALLOCATABLE, DIMENSION (:) ::  ibSurfId,ibElP1, ibElP2, ibElP3
-       INTEGER (int64), ALLOCATABLE, DIMENSION (:) :: ibNodeId,index_ts
-       REAL (dp), ALLOCATABLE, DIMENSION (:) :: xnode, ynode,  znode, xnode1, ynode1, znode1
-       INTEGER (int64) :: ibElems, ibNodes
-       INTEGER (int64) :: move_check, move_amty, move_amtx,move_amtz,blk_mv_tag
-       REAL(dp) :: ymove,ypos
-       !zpos not used
-       REAL (dp) :: xmove,xpos, zmove,zpos
-       REAL (dp) :: inity_cent, initx_cent, nxty_cent,nxtx_cent
-       REAL (dp) :: initz_cent,nxtz_cent
-       INTEGER (int64) :: cpy_x_start_mv, cpy_x_end_mv, cpy_y_start_mv, cpy_y_end_mv
-       INTEGER (int64) :: cpy_z_start_mv, cpy_z_end_mv
-       INTEGER (int64) :: cpy_x_start, cpy_x_end, cpy_y_start, cpy_y_end
-       INTEGER (int64) :: cpy_z_start, cpy_z_end
-       REAL (dp) :: theta, thetaDot, thetaDDot, piv_x,piv_y, piv_z
-       REAL (dp) :: alphaDot, thetaDot1, thetaDDot1, thetaDot2, thetaDDot2
+     INTEGER (int64), ALLOCATABLE, DIMENSION (:, :) :: fluidIndexPtr, redCellIndexPtr, &
+          blackCellIndexPtr, nodeId
+     INTEGER(int64) :: ibCellCount, solidCellCount, fluidCellCount, redCellCount, &
+          blackCellCount, TSCellCount
 
-       ! Variables from the stress calculation
-       real(dp) :: viscous_drag_coefficient, pressure_drag_coefficient
-       real(dp) :: viscous_lift_coefficient, pressure_lift_coefficient
+     INTEGER (int64), ALLOCATABLE, DIMENSION (:, :) :: TSIndexPtr, interceptedIndexPtr, &
+          solidIndexPtr
 
-    end type Block_t
+
+     INTEGER (int64), ALLOCATABLE, DIMENSION (:) :: nelp, nelu1, nelu2, nelv1, nelv2, nelw1, nelw2
+     REAL (dp), ALLOCATABLE, DIMENSION (:) :: xcent, ycent, zcent, &
+          cosAlpha, cosBeta, cosGamma, &
+          element_length, &
+          pNormDis, u1NormDis, u2NormDis , &
+          v1NormDis, v2NormDis, w1NormDis, w2NormDis, &
+          p_ghost, pt_ghost, u2_ghost, u2t_ghost, &
+          v2_ghost, v2t_ghost, w2_ghost, &
+          w2t_ghost, u1_ghost, u1t_ghost, &
+          v1_ghost, v1t_ghost, w1_ghost, w1t_ghost
+
+     INTEGER (int64), ALLOCATABLE, DIMENSION (:) ::  ibSurfId,ibElP1, ibElP2, ibElP3
+     INTEGER (int64), ALLOCATABLE, DIMENSION (:) :: ibNodeId,index_ts
+     REAL (dp), ALLOCATABLE, DIMENSION (:) :: xnode, ynode,  znode, xnode1, ynode1, znode1
+     INTEGER (int64) :: ibElems, ibNodes
+     INTEGER (int64) :: move_check, move_amty, move_amtx,move_amtz,blk_mv_tag
+     REAL(dp) :: ymove,ypos
+     !zpos not used
+     REAL (dp) :: xmove,xpos, zmove,zpos
+     REAL (dp) :: inity_cent, initx_cent, nxty_cent,nxtx_cent
+     REAL (dp) :: initz_cent,nxtz_cent
+     INTEGER (int64) :: cpy_x_start_mv, cpy_x_end_mv, cpy_y_start_mv, cpy_y_end_mv
+     INTEGER (int64) :: cpy_z_start_mv, cpy_z_end_mv
+     INTEGER (int64) :: cpy_x_start, cpy_x_end, cpy_y_start, cpy_y_end
+     INTEGER (int64) :: cpy_z_start, cpy_z_end
+     REAL (dp) :: theta, thetaDot, thetaDDot, piv_x,piv_y, piv_z
+     REAL (dp) :: alphaDot, thetaDot1, thetaDDot1, thetaDot2, thetaDDot2
+
+     ! Variables from the stress calculation
+     real(dp) :: viscous_drag_coefficient, pressure_drag_coefficient
+     real(dp) :: viscous_lift_coefficient, pressure_lift_coefficient
+
+  end type Block_t
 
 END MODULE biocfd_block_type

--- a/src/Blocks.f90
+++ b/src/Blocks.f90
@@ -1,10 +1,15 @@
 MODULE biocfd_block_type
+  !* Defines the Block_t type, which holds all the information about a
+  !* specific block.
   use, intrinsic :: iso_fortran_env, only: dp => real64, int32, int64
   IMPLICIT NONE
   private
 
   public :: Block_t
 
+  !> Block_t is a core component of the simulation, holding all the
+  !> required information about each "Block". The same type is used
+  !> for both the coarse mesh and all the fine meshes.
   type Block_t
      REAL(dp) ::  dx,dy, dz, ypth2, xpth1, xpth2, xchg,ychg, yt, ydot, yddot,&
           bfreq, yamp, xt, xdot


### PR DESCRIPTION
Two commits.

- 1ac264100df050d2f9ae1349e3eaf080f94e74d7 removes some indentation (just using emacs' indentation) in lieu of a proper formatter. This should just be whitespace changes and so if you ignore whitespace in the diff we should just see the changes from
- 7d3a7b7a5d5a17e031f6973e4055486a95d8a25d adds docstrings to the module and the type