### PR TITLE
Remove unused HDF5 variables and fix tests

### DIFF
--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.os }}-${{ matrix.toolchain.compiler }}${{ matrix.toolchain.tag }}
+    name: ${{ matrix.os }}-${{ matrix.toolchain.compiler }}${{ matrix.toolchain.tag }}-hdf5-${{ matrix.toolchain.hdf5 }}
     if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     env:
@@ -32,6 +32,11 @@ jobs:
           - compiler: gcc
             version: 14
             FPM_FFLAGS: "-Werror=unused -Werror=unused-parameter --coverage -pedantic-errors -std=f2008 -fopenmp -fopenacc"
+            hdf5: Off
+          - compiler: gcc
+            version: 14
+            FPM_FFLAGS: "-Werror=unused -Werror=unused-parameter --coverage -pedantic-errors -std=f2008 -fopenmp -fopenacc"
+            hdf5: On
           # As far as we can remember we haven't hit any issues picked
           # up by intel but not by the other compilers, while minutes
           # are limited we will not run these
@@ -41,7 +46,7 @@ jobs:
           # Separate nvidia compilations removed because using up all
           # our CI minutes!  The code now supports OpenMP+OpenACC
           # anyway, so it makes sense to just compile once
-          - {compiler: nvidia-hpc, version: '25.1', FPM_FFLAGS: "-mp -acc=multicore"}
+          - {compiler: nvidia-hpc, version: '25.1', FPM_FFLAGS: "-mp -acc=multicore", hdf5: Off }
           # Cannot currently support lfortran due to it not supporting
           # namelists (issue number 1999 lfortran)
           # - {compiler: lfortran, version: '0.55.0'}
@@ -66,6 +71,14 @@ jobs:
       - run: |
           # Install hdf5 dependency
           sudo apt install libhdf5-dev
+
+      - name: Modify fpm.toml to switch on HDF5
+        if: ${{ contains(matrix.toolchain.hdf5, 'On') }}
+        run: |
+          sed -i 's/# dependencies.hdf5/dependencies.hdf5/' fpm.toml
+          sed -i 's/"USE_HDF5=0"/"USE_HDF5=1"/' fpm.toml
+          # Just use single thread for tests when using HDF5
+          echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
 
       - name: Modify FPM_FFLAGS to include mpi flags nvhpc
         if: ${{ contains(matrix.toolchain.compiler, 'nvidia-hpc') }}

--- a/.github/workflows/setup-fortran.yml
+++ b/.github/workflows/setup-fortran.yml
@@ -31,7 +31,7 @@ jobs:
           # Compile with OpenACC and OpenMP as the default
           - compiler: gcc
             version: 14
-            FPM_FFLAGS: "-Werror=unused -Werror=unused-parameter --coverage -pedantic-errors -std=f2008 -fopenmp -fopenacc"
+            FPM_FFLAGS: "-Werror=unused -Werror=unused-parameter -pedantic-errors -std=f2008 -fopenmp -fopenacc"
             hdf5: Off
           - compiler: gcc
             version: 14

--- a/src/hdf5_io.F90
+++ b/src/hdf5_io.F90
@@ -208,7 +208,7 @@ contains
 
   subroutine hdf5_read_real_scalar(filename, group, key, output)
     integer :: error_hdf5
-    integer(hid_t) :: file_id, group_id, attr_id, attr_space_id
+    integer(hid_t) :: file_id, group_id, attr_id
     INTEGER(HSIZE_T), DIMENSION(1) :: adims
     character(len=*), intent(in) :: filename
     character(len=*), intent(in) :: group
@@ -235,7 +235,7 @@ contains
 
   subroutine hdf5_read_int_scalar(filename, group, key, output)
     integer :: error_hdf5
-    integer(hid_t) :: file_id, group_id, attr_id, attr_space_id
+    integer(hid_t) :: file_id, group_id, attr_id
     INTEGER(HSIZE_T), DIMENSION(1) :: adims
     character(len=*), intent(in) :: filename
     character(len=*), intent(in) :: group

--- a/test/test_hdf5_io.f90
+++ b/test/test_hdf5_io.f90
@@ -37,9 +37,7 @@ contains
   subroutine test_hdf5_write_real_3d(error)
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
-    integer :: i, j, k, error_hdf5
-    integer(hid_t) :: file_id, dset_id, dspace_id
-    integer(hsize_t), dimension(3) :: dims, maxdims
+    integer :: i, j, k
     character(len=*), parameter :: filename = "test_output.h5"
     character(len=*), parameter :: group = "/test_group"
     character(len=*), parameter :: key = "3d_real_array"
@@ -71,9 +69,7 @@ contains
   subroutine test_hdf5_write_real_2d(error)
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
-    integer :: j, k, error_hdf5
-    integer(hid_t) :: file_id, dset_id, dspace_id
-    integer(hsize_t), dimension(2) :: dims, maxdims
+    integer :: j, k
     character(len=*), parameter :: filename = "test_output.h5"
     character(len=*), parameter :: group = "/test_group"
     character(len=*), parameter :: key = "2d_real_array"
@@ -103,9 +99,7 @@ contains
   subroutine test_hdf5_write_real_1d(error)
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
-    integer :: k, error_hdf5
-    integer(hid_t) :: file_id, dset_id, dspace_id
-    integer(hsize_t), dimension(1) :: dims, maxdims
+    integer :: k
     character(len=*), parameter :: filename = "test_output.h5"
     character(len=*), parameter :: group = "/test_group"
     character(len=*), parameter :: key = "1d_real_array"
@@ -133,8 +127,6 @@ contains
   subroutine test_hdf5_write_real_scalar(error)
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
-    integer :: k, error_hdf5
-    integer(hid_t) :: file_id, group_id, attr_id, attr_space_id
     INTEGER(HSIZE_T), DIMENSION(1) :: adims
     character(len=*), parameter :: filename = "test_output.h5"
     character(len=*), parameter :: group = "/test_group"
@@ -157,9 +149,7 @@ contains
   subroutine test_hdf5_write_int_3d(error)
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
-    integer :: i, j, k, error_hdf5
-    integer(hid_t) :: file_id, dset_id, dspace_id
-    integer(hsize_t), dimension(3) :: dims, maxdims
+    integer :: i, j, k
     character(len=*), parameter :: filename = "test_output.h5"
     character(len=*), parameter :: group = "/test_group"
     character(len=*), parameter :: key = "3d_integer_array"
@@ -191,9 +181,7 @@ contains
   subroutine test_hdf5_write_int_2d(error)
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
-    integer :: j, k, error_hdf5
-    integer(hid_t) :: file_id, dset_id, dspace_id
-    integer(hsize_t), dimension(2) :: dims, maxdims
+    integer :: j, k
     character(len=*), parameter :: filename = "test_output.h5"
     character(len=*), parameter :: group = "/test_group"
     character(len=*), parameter :: key = "2d_integer_array"
@@ -223,9 +211,7 @@ contains
   subroutine test_hdf5_write_int_1d(error)
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
-    integer :: k, error_hdf5
-    integer(hid_t) :: file_id, dset_id, dspace_id
-    integer(hsize_t), dimension(1) :: dims, maxdims
+    integer :: k
     character(len=*), parameter :: filename = "test_output.h5"
     character(len=*), parameter :: group = "/test_group"
     character(len=*), parameter :: key = "1d_integer_array"
@@ -253,8 +239,6 @@ contains
   subroutine test_hdf5_write_int_scalar(error)
     !> Error handling
     type(error_type), allocatable, intent(out) :: error
-    integer :: k, error_hdf5
-    integer(hid_t) :: file_id, group_id, attr_id, attr_space_id
     INTEGER(HSIZE_T), DIMENSION(1) :: adims
     character(len=*), parameter :: filename = "test_output.h5"
     character(len=*), parameter :: group = "/test_group"


### PR DESCRIPTION
Removes a bunch of unused variables from `hdf5_io.F90` and `test_hdf5_io.f90`. Take the CI from #274 and modify it so that the tests are run in a single thread, which stops the errors that were previously seen.