### PR TITLE
Remove [xyz]pos variables

### DIFF
--- a/src/Blocks.f90
+++ b/src/Blocks.f90
@@ -62,9 +62,7 @@ MODULE biocfd_block_type
      REAL (dp), ALLOCATABLE, DIMENSION (:) :: xnode, ynode,  znode, xnode1, ynode1, znode1
      INTEGER (int64) :: ibElems, ibNodes
      INTEGER (int64) :: move_check, move_amty, move_amtx,move_amtz,blk_mv_tag
-     REAL(dp) :: ymove,ypos
-     !zpos not used
-     REAL (dp) :: xmove,xpos, zmove,zpos
+     REAL (dp) :: xmove, ymove, zmove
      REAL (dp) :: inity_cent, initx_cent, nxty_cent,nxtx_cent
      REAL (dp) :: initz_cent,nxtz_cent
      INTEGER (int64) :: cpy_x_start_mv, cpy_x_end_mv, cpy_y_start_mv, cpy_y_end_mv

--- a/src/Search.F90
+++ b/src/Search.F90
@@ -100,8 +100,6 @@ module biocfd_search
         blk%nxtx_cent=blk%xshift
         blk%initz_cent=blk%zshift
         blk%nxtz_cent=blk%zshift
-        blk%ypos=blk%yshift
-        blk%xpos=blk%xshift
         DO i = 1, blk%ibnodes
         IF (blk%ibNodeId(i)==51) THEN
             xr1 =  blk%xnode(i)
@@ -172,8 +170,6 @@ module biocfd_search
         blk%xmove = blk%xchg
         blk%zmove = 0.
 
-        blk%ypos =  blk%ypos  + blk%ychg
-        blk%xpos =  blk%xpos  + blk%xmove
         blk%piv_y = blk%piv_y + blk%ychg
         blk%piv_x = blk%piv_x + blk%xmove
         blk%piv_z = blk%piv_z + blk%zmove


### PR DESCRIPTION
As far as I can tell, we aren't using `[xyz]pos` anywhere, so this just removes them. This is the `grep` output

```shell
❯ grep -iwR "[xyz]pos" src app
src/Blocks.f90:     REAL(dp) :: ymove,ypos
src/Blocks.f90:     !zpos not used
src/Blocks.f90:     REAL (dp) :: xmove,xpos, zmove,zpos
src/Search.F90:        blk%ypos=blk%yshift
src/Search.F90:        blk%xpos=blk%xshift
src/Search.F90:        blk%ypos =  blk%ypos  + blk%ychg
src/Search.F90:        blk%xpos =  blk%xpos  + blk%xmove
```