### PR TITLE
Fix bug in pressureForcingGhost

### DIFF
--- a/src/Forcing.f90
+++ b/src/Forcing.f90
@@ -409,7 +409,7 @@ SUBROUTINE pressureForcingGhost(blk)
         END IF
             dpdn = ((ac_z + at_z)* blk%cosGamma(blk%nelp(blk%index_ts(n))) &
                   + (ac_y + at_y)* blk%cosBeta(blk%nelp(blk%index_ts(n)))) &
-                   + (blk%yddot*(blk%cosBeta(blk%index_ts(n))))
+                   + (blk%yddot*(blk%cosBeta(blk%nelp(blk%index_ts(n)))))
 
          sur2nodeDis = -blk%pNormDis(blk%index_ts(n))
 


### PR DESCRIPTION
Closes #278.

I had initially opened #303 but decided that it was safer and quicker to fix this in a straightforward manner.

I'm going to close #303 and we can consider that as a starting point for a future refactor (the whole `if/else if/else` to set `dpdn` can be made into its own function, since it is shared by all the `pressureForcing*` subroutines.