### PR TITLE
Deploy docs artifact to Github page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,11 +2,8 @@ name: Build documentation
 
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-    branches: [main,dev]
-#  push:
-#    branches: [main]
+  push:
+    branches: [dev]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,3 +32,16 @@ jobs:
           name: ford-docs
           path: doc
 
+  deploy:
+    needs: docs
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR deploys the docs artifact to a Github page, assuming the repo has been made public, and the settings have been changed to deploy the Github page through a workflow.