### PR TITLE
Set a maximum version for fortitude due to new rules

### DIFF
--- a/.github/workflows/fortitude-linting.yml
+++ b/.github/workflows/fortitude-linting.yml
@@ -23,8 +23,10 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13' 
+          python-version: '3.13'
       - run: |
-          python -m pip install fortitude-lint
+          # Fortitude rules up to (not including) v0.8.0 have been
+          # addressed          
+          python -m pip install "fortitude-lint<0.8.0"
           fortitude check --output-format github
 


### PR DESCRIPTION
New rules added in v0.8.0 cause the CI to fail, so pin the maximum version. Fixing them won't take too long but is more time than I have. 

#316 is the issue for fixing the new rules in v0.8.0.